### PR TITLE
Add missing header

### DIFF
--- a/src/iclient_persistence.cpp
+++ b/src/iclient_persistence.cpp
@@ -18,6 +18,7 @@
 
 #include "mqtt/iclient_persistence.h"
 #include <cstring>
+#include <cstdlib>
 
 namespace mqtt {
 


### PR DESCRIPTION
malloc(3) is declared on stdlib.h header

Signed-off-by: Guilherme Maciel Ferreira <guilherme.maciel.ferreira@gmail.com>