### PR TITLE
Fix samples build lib prefix + update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@ lib/
 obj/
 \.hg/
 \.hgignore
-
+src/samples/async_publish
+src/samples/async_subscribe
+src/samples/sync_publish

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.swp
 lib/
 obj/
 \.hg/

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ ifndef exec_prefix
   exec_prefix = ${prefix}
 endif
 
-includedir = $(prefix)/include
+includedir = $(prefix)/include/mqtt
 libdir = $(exec_prefix)/lib
 
 # ----- Definitions for the shared library -----

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,13 @@ ifndef VERBOSE
   QUIET := @
 endif
 
+ifndef INSTALL
+  INSTALL = install
+endif
+
+INSTALL_PROGRAM = $(INSTALL)
+INSTALL_DATA =  $(INSTALL) -m 644
+
 # ----- Directories -----
 
 SRC_DIR ?= src
@@ -63,9 +70,9 @@ DEPS := $(OBJS:.o=.dep)
 
 # ----- Compiler flags, etc -----
 
-CC  = $(CROSS_COMPILE)gcc
-CXX = $(CROSS_COMPILE)g++
-AR  = $(CROSS_COMPILE)ar
+CC	= $(CROSS_COMPILE)gcc
+CXX	= $(CROSS_COMPILE)g++
+AR	= $(CROSS_COMPILE)ar
 LD  = $(CROSS_COMPILE)ld
 
 CPPFLAGS += -Wall -fPIC
@@ -81,7 +88,7 @@ endif
 
 CPPFLAGS += $(addprefix -D,$(DEFS)) $(addprefix -I,$(INC_DIRS))
 
-LIB_DEPS += c stdc++ pthread 
+LIB_DEPS += c stdc++ pthread
 
 LIB_DEP_FLAGS += $(addprefix -l,$(LIB_DEPS))
 
@@ -123,6 +130,20 @@ dump:
 	@echo OBJS=$(OBJS)
 	@echo DEPS:$(DEPS)
 	@echo LIB_DEPS=$(LIB_DEPS)
+
+strip_options:
+	$(eval INSTALL_OPTS := -s)
+
+.PHONY: install
+install:
+	$(INSTALL_DATA) ${INSTALL_OPTS} $(TGT) /usr/local/lib
+	ln -s $(LIB) /usr/local/lib/$(LIB_MAJOR_LINK)
+	ln -s $(LIB_MAJOR_LINK) /usr/local/lib/$(LIB_LINK)
+
+.PHONY: uninstall
+uninstall:
+	$(RM) /usr/local/lib/$(LIB) /usr/local/lib/$(LIB_MAJOR_LINK) \
+		/usr/local/lib/$(LIB_LINK)
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,10 @@ INC_DIRS += $(INC_DIR) $(PAHO_C_INC_DIR)
 _MK_OBJ_DIR := $(shell mkdir -p $(OBJ_DIR))
 _MK_LIB_DIR := $(shell mkdir -p $(LIB_DIR))
 
+ifndef srcdir
+  srcdir = src
+endif
+
 ifndef prefix
   prefix = /usr/local
 endif
@@ -155,15 +159,36 @@ install-strip:
 .PHONY: install
 
 install:
+	mkdir -p ${includedir}
 	$(INSTALL_DATA) ${INSTALL_OPTS} $(TGT) $(libdir)
 	ln -s $(LIB) $(libdir)/$(LIB_MAJOR_LINK)
 	ln -s $(LIB_MAJOR_LINK) $(libdir)/$(LIB_LINK)
+
+	$(INSTALL_DATA) ${srcdir}/mqtt/async_client.h ${includedir}
+	$(INSTALL_DATA) ${srcdir}/mqtt/callback.h ${includedir}
+	$(INSTALL_DATA) ${srcdir}/mqtt/client.h ${includedir}
+	$(INSTALL_DATA) ${srcdir}/mqtt/connect_options.h ${includedir}
+	$(INSTALL_DATA) ${srcdir}/mqtt/delivery_token.h ${includedir}
+	$(INSTALL_DATA) ${srcdir}/mqtt/exception.h ${includedir}
+	$(INSTALL_DATA) ${srcdir}/mqtt/iaction_listener.h ${includedir}
+	$(INSTALL_DATA) ${srcdir}/mqtt/iclient_persistence.h ${includedir}
+	$(INSTALL_DATA) ${srcdir}/mqtt/ipersistable.h ${includedir}
+	$(INSTALL_DATA) ${srcdir}/mqtt/message.h ${includedir}
+	$(INSTALL_DATA) ${srcdir}/mqtt/token.h ${includedir}
+	$(INSTALL_DATA) ${srcdir}/mqtt/topic.h ${includedir}
 
 .PHONY: uninstall
 
 uninstall:
 	$(RM) $(libdir)/$(LIB) $(libdir)/$(LIB_MAJOR_LINK) \
 		$(libdir)/$(LIB_LINK)
+
+	$(RM) ${includedir}/async_client.h ${includedir}/callback.h \
+		${includedir}/client.h ${includedir}/connect_options.h \
+		${includedir}/delivery_token.h ${includedir}/exception.h \
+		${includedir}/iaction_listener.h ${includedir}/iclient_persistence.h \
+		${includedir}/ipersistable.h ${includedir}/message.h \
+		${includedir}/token.h ${includedir}/topic.h
 
 .PHONY: clean
 

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ $(OBJ_DIR)/%.o: %.cpp
 # ----- Build targets -----
 
 .PHONY: all
+
 all: $(TGT) $(LIB_DIR)/$(LIB_LINK) $(LIB_DIR)/$(LIB_MAJOR_LINK)
 
 $(TGT): $(OBJS)
@@ -116,6 +117,7 @@ $(LIB_DIR)/$(LIB_MAJOR_LINK): $(TGT)
 	$(QUIET) cd $(LIB_DIR) ; $(RM) $(LIB_MAJOR_LINK) ; ln -s $(LIB) $(LIB_MAJOR_LINK)
 
 .PHONY: dump
+
 dump:
 	@echo LIB=$(LIB)
 	@echo TGT=$(TGT)
@@ -135,28 +137,33 @@ strip_options:
 	$(eval INSTALL_OPTS := -s)
 
 .PHONY: install
+
 install:
 	$(INSTALL_DATA) ${INSTALL_OPTS} $(TGT) /usr/local/lib
 	ln -s $(LIB) /usr/local/lib/$(LIB_MAJOR_LINK)
 	ln -s $(LIB_MAJOR_LINK) /usr/local/lib/$(LIB_LINK)
 
 .PHONY: uninstall
+
 uninstall:
 	$(RM) /usr/local/lib/$(LIB) /usr/local/lib/$(LIB_MAJOR_LINK) \
 		/usr/local/lib/$(LIB_LINK)
 
 .PHONY: clean
+
 clean:
 	$(QUIET) $(RM) $(TGT) $(LIB_DIR)/$(LIB_LINK) $(LIB_DIR)/$(LIB_MAJOR_LINK) \
 	    $(OBJS)
 
 .PHONY: distclean
+
 distclean: clean
 	$(QUIET) rm -rf $(OBJ_DIR) $(LIB_DIR)
 
 # ----- Header dependencies -----
 
 MKG := $(findstring $(MAKECMDGOALS),"clean distclean dump")
+
 ifeq "$(MKG)" ""
   -include $(DEPS)
 endif

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -1,0 +1,68 @@
+#! /bin/bash
+
+###############################################################################
+# This script installs Ninja build system and Eclipse Paho MQTT C Client as a
+# prerequisites in order to compile and install Eclipse Paho MQTT C++ CLient.
+#
+# - Ninja is required by Eclipse Paho MQTT C Client for building it.
+#
+# - Eclipse Paho MQTT C Client is required by the C++ Client for building it.
+###############################################################################
+
+REQ_PKGS="build-essential gcc make cmake cmake-gui cmake-curses-gui re2c"
+MQTT_C_CLIENT_VERSION="1.1.0"
+BASE_URL="http://build.eclipse.org/technology/paho/C/"
+
+function install_ninja() {
+    git clone https://github.com/ninja-build/ninja
+    cd ninja
+    git checkout release
+    ./configure.py --bootstrap
+    sudo ln -s ${PWD}/ninja /sbin/ninja
+}
+
+# Preferred method for installing Eclipse Paho MQTT C Client
+function install_mqtt_c_client_from_github() {
+    git clone https://github.com/eclipse/paho.mqtt.c.git
+    mkdir -p paho.mqtt.c/build/output
+    cd paho.mqtt.c/build/output
+    mqtt_c_src="../../src"
+    cmake -GNinja -DPAHO_WITH_SSL=TRUE \
+        -DPAHO_BUILD_DOCUMENTATION=FALSE \
+        -DPAHO_BUILD_SAMPLES=TRUE $mqtt_c_src
+    ninja
+    cd ../../
+    sudo make install
+}
+
+# Alternative method for installing Eclipse Paho MQTT C Client
+function install_mqtt_c_client_from_eclipse_src() {
+    mqtt_c_src="eclipse-paho-mqtt-c-src-${MQTT_C_CLIENT_VERISON}"
+    tarball="${mqtt_c_src}.tar.gz"
+    base_path="~/Downloads"
+    path_mqtt_c="${base_path}/${mqtt_c_src}"
+    mkdir -p $path_mqtt_c
+    wget -O $base_path "${BASE_URL}/${MQTT_C_CLIENT_VERISON}/${tarball}"
+    cd $base_path
+    tar xzvf $tarball -C $mqtt_c_src
+    cd $path_mqtt_c
+    mkdir build
+    cd build
+    cmake -GNinja -DPAHO_WITH_SSL=TRUE \
+        -DPAHO_BUILD_DOCUMENTATION=FALSE \
+        -DPAHO_BUILD_SAMPLES=TRUE $path_mqtt_c/src/
+    ninja
+    cd ../
+    sudo make install
+}
+
+# By default use the preferred method for installing Eclipse Paho MQTT C Client
+function install_mqtt_c_client() {
+    install_mqtt_c_client_from_github
+}
+
+sudo apt-get install -y $REQ_PKGS
+install_ninja
+install_mqtt_c_client
+
+exit

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -26,10 +26,9 @@ function install_mqtt_c_client_from_github() {
     git clone https://github.com/eclipse/paho.mqtt.c.git
     mkdir -p paho.mqtt.c/build/output
     cd paho.mqtt.c/build/output
-    mqtt_c_src="../../src"
     cmake -GNinja -DPAHO_WITH_SSL=TRUE \
         -DPAHO_BUILD_DOCUMENTATION=FALSE \
-        -DPAHO_BUILD_SAMPLES=TRUE $mqtt_c_src
+        -DPAHO_BUILD_SAMPLES=TRUE ../../
     ninja
     cd ../../
     sudo make install

--- a/src/samples/Makefile
+++ b/src/samples/Makefile
@@ -1,6 +1,13 @@
 # Makefile for the paho-mqttpp (C++) sample applications
 
-PAHO_C_LIB ?= $(abspath ../../../org.eclipse.paho.mqtt.c)
+# Check if paho mqtt C libs are installed into the system, and use them.
+ifneq (,$(wildcard /usr/local/lib/libpaho-mqtt*))
+PAHO_C_LIB = /usr/local/lib
+LDLIBS += -L../../lib -L$(PAHO_C_LIB) -lpaho-mqttpp3 -lpaho-mqtt3a
+else
+PAHO_C_LIB ?= $(abspath ../../../paho.mqtt.c)
+LDLIBS += -L../../lib -L$(PAHO_C_LIB)/build/output -lpaho-mqttpp3 -lpaho-mqtt3a
+endif
 
 all: async_publish async_subscribe sync_publish
 
@@ -15,7 +22,6 @@ else
   CXXFLAGS += -O2
 endif
 
-LDLIBS += -L../../lib -L$(PAHO_C_LIB)/build/output -lpaho-mqttpp3 -lpaho-mqtt3a
 
 async_publish: async_publish.cpp
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ $< $(LDLIBS)
@@ -32,5 +38,4 @@ clean:
 	rm -f async_publish async_subscribe sync_publish
 
 distclean: clean
-
 

--- a/src/samples/Makefile
+++ b/src/samples/Makefile
@@ -3,7 +3,7 @@
 # Check if paho mqtt C libs are installed into the system, and use them.
 ifneq (,$(wildcard /usr/local/lib/libpaho-mqtt*))
 PAHO_C_LIB = /usr/local/lib
-LDLIBS += -L../../lib -L$(PAHO_C_LIB) -lpaho-mqttpp3 -lpaho-mqtt3a
+LDLIBS += -L$(PAHO_C_LIB) -lpaho-mqttpp3 -lpaho-mqtt3a
 else
 PAHO_C_LIB ?= $(abspath ../../../paho.mqtt.c)
 LDLIBS += -L../../lib -L$(PAHO_C_LIB)/build/output -lpaho-mqttpp3 -lpaho-mqtt3a


### PR DESCRIPTION
This set of commits solves the following issues:
- Fix the path for paho mqtt c libraries and use those installed into the system first. If they are not 
  installed, use those complied inside paho mqtt c repository.
- Add install/uninstall targets for the Makefile in order to install libpaho-mqttpp libarry into the system.
- Update .gitignore to not include the sample binaries and other generated files.
- Add script for automating the installation of Eclipse Paho MQTT C++ Client requirements.
