### PR TITLE
Replace the to_str() by the operator<<

### DIFF
--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -1,0 +1,26 @@
+// exception.cpp
+
+/*******************************************************************************
+ * Copyright (c) 2016 Guilherme M. Ferreira <guilherme.maciel.ferreira@gmail.com>
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Guilherme M. Ferreira - add insertion operator (<<)
+ *******************************************************************************/
+
+
+#include "mqtt/exception.h"
+
+std::ostream& operator<<(std::ostream& os, const mqtt::exception& ex)
+{
+	os << std::string(ex.what());
+	return os;
+}

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -131,3 +131,14 @@ void message::set_payload(const std::string& payload)
 // end namespace mqtt
 }
 
+std::ostream& operator<<(std::ostream& os, const mqtt::message& msg)
+{
+	os << std::string(msg.get_payload());
+	return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const mqtt::message_ptr msg)
+{
+	os << std::string(msg->get_payload());
+	return os;
+}

--- a/src/mqtt/connect_options.h
+++ b/src/mqtt/connect_options.h
@@ -183,7 +183,6 @@ public:
 	 */
 	/*protected*/ void set_will(const std::string& top, message msg, int qos, bool retained);
 
-	std::string to_str() const;
 };
 
 /**

--- a/src/mqtt/exception.h
+++ b/src/mqtt/exception.h
@@ -58,11 +58,6 @@ public:
 	 */
 	int get_reason_code() const { return code_; }
 	/**
-	 * Returns a string representation of this exception. 
-	 * @return A string representation of this exception. 
-	 */
-	std::string to_str() const { return std::string(what()); }
-	/**
 	 * Returns an explanatory string for the exception.
 	 * @return const char* 
 	 */
@@ -100,6 +95,11 @@ public:
 /////////////////////////////////////////////////////////////////////////////
 // end namespace mqtt
 }
+
+/**
+ * Output stream operator for mqtt::exception
+ */
+std::ostream& operator<<(std::ostream& os, const mqtt::exception& ex);
 
 #endif		// __mqtt_token_h
 

--- a/src/mqtt/message.h
+++ b/src/mqtt/message.h
@@ -169,11 +169,6 @@ public:
 	 */
 	void set_retained(bool retained) { msg_.retained = (retained) ? (!0) : 0; }
 	/**
-	 * Returns a string representation of this messages payload. 
-	 * @return std::string 
-	 */
-	std::string to_str() const { return get_payload(); }
-	/**
 	 * Determines if the QOS value is a valid one.
 	 * @param qos The QOS value.
 	 * @throw std::invalid_argument If the qos value is invalid.
@@ -211,6 +206,14 @@ inline message_ptr make_message(const std::string& payload) {
 /////////////////////////////////////////////////////////////////////////////
 // end namespace mqtt
 }
+
+/**
+ * Output stream operator for mqtt::message
+ */
+
+std::ostream& operator<<(std::ostream& os, const mqtt::message& msg);
+
+std::ostream& operator<<(std::ostream& os, const mqtt::message_ptr msg);
 
 #endif		// __mqtt_message_h
 

--- a/src/mqtt/topic.h
+++ b/src/mqtt/topic.h
@@ -95,11 +95,6 @@ public:
 	 * @return delivery_token 
 	 */
 	idelivery_token_ptr publish(message_ptr msg);
-	/**
-	 * Returns a string representation of this topic.
-	 * @return std::string 
-	 */
-	std::string to_str() const { return name_; }
 };
 
 /**
@@ -110,6 +105,11 @@ typedef topic::ptr_t topic_ptr;
 /////////////////////////////////////////////////////////////////////////////
 // end namespace mqtt
 }
+
+/**
+ * Output stream operator for mqtt::topic
+ */
+std::ostream& operator<<(std::ostream& os, const mqtt::topic& tp);
 
 #endif		// __mqtt_topic_h
 

--- a/src/samples/async_subscribe.cpp
+++ b/src/samples/async_subscribe.cpp
@@ -116,7 +116,7 @@ class callback : public virtual mqtt::callback,
 	virtual void message_arrived(const std::string& topic, mqtt::message_ptr msg) {
 		std::cout << "Message arrived" << std::endl;
 		std::cout << "\ttopic: '" << topic << "'" << std::endl;
-		std::cout << "\t'" << msg->to_str() << "'\n" << std::endl;
+		std::cout << "\t'" << msg << "'\n" << std::endl;
 	}
 
 	virtual void delivery_complete(mqtt::idelivery_token_ptr token) {}

--- a/src/topic.cpp
+++ b/src/topic.cpp
@@ -39,5 +39,8 @@ idelivery_token_ptr topic::publish(message_ptr msg)
 // end namespace mqtt
 }
 
-
-
+std::ostream& operator<<(std::ostream& os, const mqtt::topic& tp)
+{
+	os << tp.get_name();
+	return os;
+}


### PR DESCRIPTION
The insertion operator (<<) is the standard way C++ handles output.
The to_str() is a Java way of outputing string.

Signed-off-by: Guilherme Maciel Ferreira <guilherme.maciel.ferreira@gmail.com>