### PR TITLE
Use named C++ casts instead of C-Style casts

### DIFF
--- a/src/async_client.cpp
+++ b/src/async_client.cpp
@@ -285,7 +285,8 @@ itoken_ptr async_client::disconnect(long timeout)
 	itoken_ptr tok = std::make_shared<token>(*this);
 	add_token(tok);
 
-	disconnect_options opts(int(timeout), dynamic_cast<token*>(tok.get()));
+	// TODO may truncate timeout
+	disconnect_options opts(static_cast<int>(timeout), dynamic_cast<token*>(tok.get()));
 
 	int rc = MQTTAsync_disconnect(cli_, &opts.opts_);
 
@@ -304,7 +305,8 @@ itoken_ptr async_client::disconnect(long timeout, void* userContext, iaction_lis
 	tok->set_action_callback(cb);
 	add_token(tok);
 
-	disconnect_options opts(int(timeout), dynamic_cast<token*>(tok.get()));
+	// TODO may truncate timeout
+	disconnect_options opts(static_cast<int>(timeout), dynamic_cast<token*>(tok.get()));
 
 	int rc = MQTTAsync_disconnect(cli_, &opts.opts_);
 
@@ -366,7 +368,7 @@ idelivery_token_ptr async_client::publish(const std::string& topic, const_messag
 
 	delivery_response_options opts(dynamic_cast<delivery_token*>(tok.get()));
 
-	int rc = MQTTAsync_sendMessage(cli_, (char*) topic.c_str(), &(msg->msg_), 
+	int rc = MQTTAsync_sendMessage(cli_, topic.c_str(), &(msg->msg_),
 								   &opts.opts_);
 
 	if (rc != MQTTASYNC_SUCCESS) {
@@ -387,7 +389,7 @@ idelivery_token_ptr async_client::publish(const std::string& topic, const_messag
 
 	delivery_response_options opts(dynamic_cast<delivery_token*>(tok.get()));
 
-	int rc = MQTTAsync_sendMessage(cli_, (char*) topic.c_str(), &(msg->msg_), 
+	int rc = MQTTAsync_sendMessage(cli_, topic.c_str(), &(msg->msg_),
 								   &opts.opts_);
 
 	if (rc != MQTTASYNC_SUCCESS) {
@@ -431,8 +433,9 @@ itoken_ptr async_client::subscribe(const topic_filter_collection& topicFilters,
 
 	response_options opts(dynamic_cast<token*>(tok.get()));
 
-	int rc = MQTTAsync_subscribeMany(cli_, (int) topicFilters.size(),
-									 (char**) &filts[0], (int*) &qos[0], &opts.opts_);
+	int rc = MQTTAsync_subscribeMany(cli_, static_cast<int>(topicFilters.size()),
+									 static_cast<char**>(&filts[0]),
+									 const_cast<int*>(&qos[0]), &opts.opts_);
 
 	free_topic_filters(filts);
 	if (rc != MQTTASYNC_SUCCESS) {
@@ -461,8 +464,9 @@ itoken_ptr async_client::subscribe(const topic_filter_collection& topicFilters,
 
 	response_options opts(dynamic_cast<token*>(tok.get()));
 
-	int rc = MQTTAsync_subscribeMany(cli_, (int) topicFilters.size(),
-									 (char**) &filts[0], (int*) &qos[0], &opts.opts_);
+	int rc = MQTTAsync_subscribeMany(cli_, static_cast<int>(topicFilters.size()),
+									 static_cast<char**>(&filts[0]),
+									 const_cast<int*>(&qos[0]), &opts.opts_);
 
 	free_topic_filters(filts);
 	if (rc != MQTTASYNC_SUCCESS) {
@@ -480,7 +484,7 @@ itoken_ptr async_client::subscribe(const std::string& topicFilter, int qos)
 
 	response_options opts(dynamic_cast<token*>(tok.get()));
 
-	int rc = MQTTAsync_subscribe(cli_, (char*) topicFilter.c_str(), qos, &opts.opts_);
+	int rc = MQTTAsync_subscribe(cli_, topicFilter.c_str(), qos, &opts.opts_);
 
 	if (rc != MQTTASYNC_SUCCESS) {
 		remove_token(tok);
@@ -500,7 +504,7 @@ itoken_ptr async_client::subscribe(const std::string& topicFilter, int qos,
 
 	response_options opts(dynamic_cast<token*>(tok.get()));
 
-	int rc = MQTTAsync_subscribe(cli_, (char*) topicFilter.c_str(), qos, &opts.opts_);
+	int rc = MQTTAsync_subscribe(cli_, topicFilter.c_str(), qos, &opts.opts_);
 
 	if (rc != MQTTASYNC_SUCCESS) {
 		remove_token(tok);
@@ -520,7 +524,7 @@ itoken_ptr async_client::unsubscribe(const std::string& topicFilter)
 
 	response_options opts(dynamic_cast<token*>(tok.get()));
 
-	int rc = MQTTAsync_unsubscribe(cli_, (char*) topicFilter.c_str(), &opts.opts_);
+	int rc = MQTTAsync_unsubscribe(cli_, topicFilter.c_str(), &opts.opts_);
 
 	if (rc != MQTTASYNC_SUCCESS) {
 		remove_token(tok);
@@ -540,7 +544,7 @@ itoken_ptr async_client::unsubscribe(const topic_filter_collection& topicFilters
 
 	response_options opts(dynamic_cast<token*>(tok.get()));
 
-	int rc = MQTTAsync_unsubscribeMany(cli_, (int) n, (char**) &filts[0], &opts.opts_);
+	int rc = MQTTAsync_unsubscribeMany(cli_, static_cast<int>(n), static_cast<char**>(&filts[0]), &opts.opts_);
 
 	free_topic_filters(filts);
 	if (rc != MQTTASYNC_SUCCESS) {
@@ -564,7 +568,7 @@ itoken_ptr async_client::unsubscribe(const topic_filter_collection& topicFilters
 
 	response_options opts(dynamic_cast<token*>(tok.get()));
 
-	int rc = MQTTAsync_unsubscribeMany(cli_, (int) n, (char**) &filts[0], &opts.opts_);
+	int rc = MQTTAsync_unsubscribeMany(cli_, static_cast<int>(n), static_cast<char**>(&filts[0]), &opts.opts_);
 
 	free_topic_filters(filts);
 	if (rc != MQTTASYNC_SUCCESS) {
@@ -585,7 +589,7 @@ itoken_ptr async_client::unsubscribe(const std::string& topicFilter,
 
 	response_options opts(dynamic_cast<token*>(tok.get()));
 
-	int rc = MQTTAsync_unsubscribe(cli_, (char*) topicFilter.c_str(), &opts.opts_);
+	int rc = MQTTAsync_unsubscribe(cli_, topicFilter.c_str(), &opts.opts_);
 
 	if (rc != MQTTASYNC_SUCCESS) {
 		remove_token(tok);

--- a/src/iclient_persistence.cpp
+++ b/src/iclient_persistence.cpp
@@ -143,8 +143,8 @@ int iclient_persistence::persistence_get(void* handle, char* key,
 			if (!p->get_payload_bytes()) payloadlen = 0;
 
 			// TODO: Check range
-			*buflen = (int) (hdrlen + payloadlen);
-			char* buf = (char*) malloc(*buflen);
+			*buflen = static_cast<int>(hdrlen + payloadlen);
+			char* buf = static_cast<char*>(malloc(*buflen));
 			std::memcpy(buf, p->get_header_bytes(), hdrlen);
 			std::memcpy(buf+hdrlen, p->get_payload_bytes(), payloadlen);
 			*buffer = buf;
@@ -180,10 +180,10 @@ int iclient_persistence::persistence_keys(void* handle, char*** keys, int* nkeys
 			if (n == 0)
 				*keys = nullptr;
 			else {
-				*keys = (char**) malloc(n*sizeof(char*));
+				*keys = static_cast<char**>(malloc(n*sizeof(char*)));
 				for (size_t i=0; i<n; ++i) {
 					size_t len = k[i].size();
-					(*keys)[i] = (char*) malloc(len+1);
+					(*keys)[i] = static_cast<char*>(malloc(len+1));
 					std::memcpy((*keys)[i], k[i].data(), len);
 					(*keys)[i][len] = '\0';
 				}

--- a/src/mqtt/token.h
+++ b/src/mqtt/token.h
@@ -238,7 +238,7 @@ public:
 	 * @return iasync_client
 	 */
 	virtual iasync_client* get_client() const {
-		return (iasync_client*) cli_;
+		return cli_;
 	}
 	/**
 	 * Returns an exception providing more detail if an operation failed.
@@ -250,7 +250,10 @@ public:
 	 * token.
 	 * @return int
 	 */
-	virtual int get_message_id() const { return int(tok_); }
+	virtual int get_message_id() const {
+		static_assert(sizeof(tok_) == sizeof(int), "MQTTAsync_token must fit into int");
+		return static_cast<int>(tok_);
+	}
 	/**
 	 * Returns the topic string(s) for the action being tracked by this
 	 * token.
@@ -305,7 +308,7 @@ public:
 	 */
 	template <class Rep, class Period>
 	bool wait_for_completion(const std::chrono::duration<Rep, Period>& relTime) {
-		wait_for_completion((long) std::chrono::duration_cast<std::chrono::milliseconds>(relTime).count());
+		wait_for_completion(static_cast<long>(std::chrono::duration_cast<std::chrono::milliseconds>(relTime).count()));
 		return rc_ == 0;
 	}
 	/**


### PR DESCRIPTION
Replace function-style casts (i.e. T(v)) and C-Style casts (i.e. (T)v) by named casts. This provides a better error checking and prevents conversion bugs.

Signed-off-by: Guilherme Maciel Ferreira guilherme.maciel.ferreira@gmail.com
