### PR TITLE
Use the same semantic as Paho MQTT C for invalid strings

### DIFF
--- a/src/ssl_options.cpp
+++ b/src/ssl_options.cpp
@@ -33,11 +33,14 @@ ssl_options::ssl_options(const ssl_options& opt)
 			privateKey_(opt.privateKey_), privateKeyPassword_(opt.privateKeyPassword_),
 			enabledCipherSuites_(opt.enabledCipherSuites_)
 {
-	opts_.trustStore = trustStore_.c_str();
-	opts_.keyStore = keyStore_.c_str();
-	opts_.privateKey = privateKey_.c_str();
-	opts_.privateKeyPassword = privateKeyPassword_.c_str();
-	opts_.enabledCipherSuites = enabledCipherSuites_.c_str();
+	// NOTE: By default, the Paho C treats nullptr char arrays as unset values,
+	// so we keep that semantic and only set those char arrays if the string
+	// is non-empty
+	opts_.trustStore = trustStore_.empty() ? nullptr : trustStore_.c_str();
+	opts_.keyStore = keyStore_.empty() ? nullptr : keyStore_.c_str();
+	opts_.privateKey = privateKey_.empty() ? nullptr : privateKey_.c_str();
+	opts_.privateKeyPassword = privateKeyPassword_.empty() ? nullptr : privateKeyPassword_.c_str();
+	opts_.enabledCipherSuites = enabledCipherSuites_.empty() ? nullptr : enabledCipherSuites_.c_str();
 }
 
 ssl_options::ssl_options(ssl_options&& opt)
@@ -46,11 +49,14 @@ ssl_options::ssl_options(ssl_options&& opt)
 			privateKeyPassword_(std::move(opt.privateKeyPassword_)),
 			enabledCipherSuites_(std::move(opt.enabledCipherSuites_))
 {
-	opts_.trustStore = trustStore_.c_str();
-	opts_.keyStore = keyStore_.c_str();
-	opts_.privateKey = privateKey_.c_str();
-	opts_.privateKeyPassword = privateKeyPassword_.c_str();
-	opts_.enabledCipherSuites = enabledCipherSuites_.c_str();
+	// NOTE: By default, the Paho C treats nullptr char arrays as unset values,
+	// so we keep that semantic and only set those char arrays if the string
+	// is non-empty
+	opts_.trustStore = trustStore_.empty() ? nullptr : trustStore_.c_str();
+	opts_.keyStore = keyStore_.empty() ? nullptr : keyStore_.c_str();
+	opts_.privateKey = privateKey_.empty() ? nullptr : privateKey_.c_str();
+	opts_.privateKeyPassword = privateKeyPassword_.empty() ? nullptr : privateKeyPassword_.c_str();
+	opts_.enabledCipherSuites = enabledCipherSuites_.empty() ? nullptr : enabledCipherSuites_.c_str();
 }
 
 ssl_options& ssl_options::operator=(const ssl_options& rhs)
@@ -66,11 +72,14 @@ ssl_options& ssl_options::operator=(const ssl_options& rhs)
 	privateKeyPassword_ = rhs.privateKeyPassword_;
 	enabledCipherSuites_ = rhs.enabledCipherSuites_;
 
-	opts_.trustStore = trustStore_.c_str();
-	opts_.keyStore = keyStore_.c_str();
-	opts_.privateKey = privateKey_.c_str();
-	opts_.privateKeyPassword = privateKeyPassword_.c_str();
-	opts_.enabledCipherSuites = enabledCipherSuites_.c_str();
+	// NOTE: By default, the Paho C treats nullptr char arrays as unset values,
+	// so we keep that semantic and only set those char arrays if the string
+	// is non-empty
+	opts_.trustStore = trustStore_.empty() ? nullptr : trustStore_.c_str();
+	opts_.keyStore = keyStore_.empty() ? nullptr : keyStore_.c_str();
+	opts_.privateKey = privateKey_.empty() ? nullptr : privateKey_.c_str();
+	opts_.privateKeyPassword = privateKeyPassword_.empty() ? nullptr : privateKeyPassword_.c_str();
+	opts_.enabledCipherSuites = enabledCipherSuites_.empty() ? nullptr : enabledCipherSuites_.c_str();
 
 	return *this;
 }
@@ -92,11 +101,14 @@ ssl_options& ssl_options::operator=(ssl_options&& rhs)
 	// but just to be safe
 	std::memset(&rhs.opts_, 0, sizeof(MQTTAsync_SSLOptions));
 
-	opts_.trustStore = trustStore_.c_str();
-	opts_.keyStore = keyStore_.c_str();
-	opts_.privateKey = privateKey_.c_str();
-	opts_.privateKeyPassword = privateKeyPassword_.c_str();
-	opts_.enabledCipherSuites = enabledCipherSuites_.c_str();
+	// NOTE: By default, the Paho C treats nullptr char arrays as unset values,
+	// so we keep that semantic and only set those char arrays if the string
+	// is non-empty
+	opts_.trustStore = trustStore_.empty() ? nullptr : trustStore_.c_str();
+	opts_.keyStore = keyStore_.empty() ? nullptr : keyStore_.c_str();
+	opts_.privateKey = privateKey_.empty() ? nullptr : privateKey_.c_str();
+	opts_.privateKeyPassword = privateKeyPassword_.empty() ? nullptr : privateKeyPassword_.c_str();
+	opts_.enabledCipherSuites = enabledCipherSuites_.empty() ? nullptr : enabledCipherSuites_.c_str();
 
 	return *this;
 }
@@ -104,31 +116,31 @@ ssl_options& ssl_options::operator=(ssl_options&& rhs)
 void ssl_options::set_trust_store(const std::string& trustStore)
 {
 	trustStore_ = trustStore;
-	opts_.trustStore = trustStore_.c_str();
+	opts_.trustStore = trustStore_.empty() ? nullptr : trustStore_.c_str();
 }
 
 void ssl_options::set_key_store(const std::string& keyStore)
 {
 	keyStore_ = keyStore;
-	opts_.keyStore = keyStore_.c_str();
+	opts_.keyStore = keyStore_.empty() ? nullptr : keyStore_.c_str();
 }
 
 void ssl_options::set_private_key(const std::string& privateKey)
 {
 	privateKey_ = privateKey;
-	opts_.privateKey = privateKey_.c_str();
+	opts_.privateKey = privateKey_.empty() ? nullptr : privateKey_.c_str();
 }
 
 void ssl_options::set_private_key_password(const std::string& privateKeyPassword)
 {
 	privateKeyPassword_ = privateKeyPassword;
-	opts_.privateKeyPassword = privateKeyPassword_.c_str();
+	opts_.privateKeyPassword = privateKeyPassword_.empty() ? nullptr : privateKeyPassword_.c_str();
 }
 
 void ssl_options::set_enabled_cipher_suites(const std::string& enabledCipherSuites)
 {
 	enabledCipherSuites_ = enabledCipherSuites;
-	opts_.enabledCipherSuites = enabledCipherSuites_.c_str();
+	opts_.enabledCipherSuites = enabledCipherSuites_.empty() ? nullptr : enabledCipherSuites_.c_str();
 }
 
 void ssl_options::set_enable_server_cert_auth(bool enableServerCertAuth)


### PR DESCRIPTION
When connecting with a SSL enabled server, the Paho client issues the
following errors:

  SSL routines:SSL_CTX_use_certificate_chain_file:system lib:ssl_rsa.c:701
  SSL routines:FILE_CTRL:system lib:bss_file.c:400

The error is caused because the SSLSocket_createContext() function
uses the MQTTClient_SSLOptions's members (keyStore, trustStore and
enabledCipherSuites) even if they are empty strings. The only way the
function doesn't use a particular member is setting it to NULL.

However, the ssl_options's constructors and assignment operators
initialize the members keyStore, trustStore and enabledCipherSuites
with empty strings (std::strings::c_str()).

So, despite setting only the trustStore, the user ends up passing
all members as valid, not NULL, strings. Then, SSLSocket_createContext()
calls SSL_CTX_use_certificate_chain_file() using an empty keyStore.

The call stack to the problem is:

  ----------- Paho MQTT C++ ------------
    async_client::connect()
  ----------- Paho MQTT C ------------
    MQTTAsync_connect()
    MQTTAsync_receiveThread()
    MQTTAsync_cycle()
    MQTTAsync_connecting()
    SSLSocket_setSocketForSSL()
    SSLSocket_createContext()
  ----------- OpenSSL -----------------
    SSL_CTX_use_certificate_chain_file()
    BIO_read_filename()

In order to solve the problem, the ssl_options class only inititalizes
a MQTTAsync_SSLOptions member if the string is not empty. So both C and
C++ libraries agree that NULL is a invalid string.

Signed-off-by: Guilherme Maciel Ferreira guilherme.maciel.ferreira@gmail.com
