### PR TITLE
Use "override" instead of "virtual" for inherited member functions

### DIFF
--- a/src/iclient_persistence.cpp
+++ b/src/iclient_persistence.cpp
@@ -48,18 +48,18 @@ public:
 				payload_(static_cast<const uint8_t*>(payload)), payloadlen_(payloadlen) 
 	{}
 
-	virtual const uint8_t* get_header_bytes() const { return hdr_; }
-	virtual size_t get_header_length() const { return hdrlen_; }
-	virtual size_t get_header_offset() const { return 0; }
+	const uint8_t* get_header_bytes() const override { return hdr_; }
+	size_t get_header_length() const override { return hdrlen_; }
+	size_t get_header_offset() const override { return 0; }
 
-	virtual const uint8_t* get_payload_bytes() const { return payload_; }
-	virtual size_t get_payload_length() const { return payloadlen_; }
-	virtual size_t get_payload_offset() const { return 0; }
+	const uint8_t* get_payload_bytes() const override { return payload_; }
+	size_t get_payload_length() const override { return payloadlen_; }
+	size_t get_payload_offset() const override { return 0; }
 
-	virtual std::vector<uint8_t> get_header_byte_arr() const {
+	std::vector<uint8_t> get_header_byte_arr() const override {
 		return std::vector<uint8_t>(hdr_, hdr_+hdrlen_);
 	}
-	virtual std::vector<uint8_t> get_payload_byte_arr() const {
+	std::vector<uint8_t> get_payload_byte_arr() const override {
 		return std::vector<uint8_t>(payload_, payload_+payloadlen_);
 	}
 };

--- a/src/mqtt/async_client.h
+++ b/src/mqtt/async_client.h
@@ -153,7 +153,7 @@ public:
 	/**
 	 * Destructor
 	 */
-	~async_client();
+	~async_client() override;
 	/**
 	 * Connects to an MQTT server using the default options.
 	 * @return token used to track and wait for the connect to complete. The
@@ -161,7 +161,7 @@ public:
 	 * @throw exception for non security related problems
 	 * @throw security_exception for security related problems
 	 */
-	virtual itoken_ptr connect();
+	itoken_ptr connect() override;
 	/**
 	 * Connects to an MQTT server using the provided connect options.
 	 * @param options a set of connection parameters that override the
@@ -171,7 +171,7 @@ public:
 	 * @throw exception for non security related problems
 	 * @throw security_exception for security related problems
 	 */
-	virtual itoken_ptr connect(connect_options options);
+	itoken_ptr connect(connect_options options) override;
 	/**
 	 * Connects to an MQTT server using the specified options.
 	 * @param options a set of connection parameters that override the
@@ -185,8 +185,8 @@ public:
 	 * @throw exception for non security related problems
 	 * @throw security_exception for security related problems
 	 */
-	virtual itoken_ptr connect(connect_options options, void* userContext,
-							   iaction_listener& cb);
+	itoken_ptr connect(connect_options options, void* userContext,
+							   iaction_listener& cb) override;
 	/**
 	 *
 	 * @param userContext optional object used to pass context to the
@@ -198,14 +198,14 @@ public:
 	 * @throw exception for non security related problems
 	 * @throw security_exception for security related problems
 	 */
-	virtual itoken_ptr connect(void* userContext, iaction_listener& cb);
+	itoken_ptr connect(void* userContext, iaction_listener& cb) override;
 	/**
 	 * Disconnects from the server.
 	 * @return token used to track and wait for the disconnect to complete.
 	 *  	   The token will be passed to any callback that has been set.
 	 * @throw exception for problems encountered while disconnecting
 	 */
-	virtual itoken_ptr disconnect() { return disconnect(0L); }
+	itoken_ptr disconnect() override { return disconnect(0L); }
 	/**
 	 * Disconnects from the server.
 	 *
@@ -218,7 +218,7 @@ public:
 	 *  	   set.
 	 * @throw exception for problems encountered while disconnecting
 	 */
-	virtual itoken_ptr disconnect(long quiesceTimeout);
+	itoken_ptr disconnect(long quiesceTimeout) override;
 	/**
 	 * Disconnects from the server.
 	 *
@@ -235,8 +235,8 @@ public:
 	 *  	   a callback is set.
 	 * @throw exception for problems encountered while disconnecting
 	 */
-	virtual itoken_ptr disconnect(long quiesceTimeout, void* userContext,
-								  iaction_listener& cb);
+	itoken_ptr disconnect(long quiesceTimeout, void* userContext,
+								  iaction_listener& cb) override;
 	/**
 	 * Disconnects from the server.
 	 * @param userContext optional object used to pass context to the
@@ -248,34 +248,34 @@ public:
 	 *  	   a callback is set.
 	 * @throw exception for problems encountered while disconnecting
 	 */
-	virtual itoken_ptr disconnect(void* userContext, iaction_listener& cb) {
+	itoken_ptr disconnect(void* userContext, iaction_listener& cb) override {
 		return disconnect(0L, userContext, cb);
 	}
 	/**
 	 * Returns the delivery token for the specified message ID.
 	 * @return idelivery_token
 	 */
-	virtual idelivery_token_ptr get_pending_delivery_token(int msgID) const;
+	idelivery_token_ptr get_pending_delivery_token(int msgID) const override;
 	/**
 	 * Returns the delivery tokens for any outstanding publish operations.
 	 * @return idelivery_token[]
 	 */
-	virtual std::vector<idelivery_token_ptr> get_pending_delivery_tokens() const;
+	std::vector<idelivery_token_ptr> get_pending_delivery_tokens() const override;
 	/**
 	 * Returns the client ID used by this client.
 	 * @return The client ID used by this client.
 	 */
-	virtual std::string get_client_id() const { return clientId_; }
+	std::string get_client_id() const override { return clientId_; }
 	/**
 	 * Returns the address of the server used by this client.
 	 * @return The server's address, as a URI String.
 	 */
-	virtual std::string get_server_uri() const { return serverURI_; }
+	std::string get_server_uri() const override { return serverURI_; }
 	/**
 	 * Determines if this client is currently connected to the server.
 	 * @return true if connected, false otherwise.
 	 */
-	virtual bool is_connected() const { return MQTTAsync_isConnected(cli_) != 0; }
+	bool is_connected() const override { return MQTTAsync_isConnected(cli_) != 0; }
 	/**
 	 * Publishes a message to a topic on the server
 	 * @param topic The topic to deliver the message to
@@ -288,8 +288,8 @@ public:
 	 * @return token used to track and wait for the publish to complete. The
 	 *  	   token will be passed to callback methods if set.
 	 */
-	virtual idelivery_token_ptr publish(const std::string& topic, const void* payload,
-										size_t n, int qos, bool retained);
+	idelivery_token_ptr publish(const std::string& topic, const void* payload,
+										size_t n, int qos, bool retained) override;
 	/**
 	 * Publishes a message to a topic on the server
 	 * @param topic The topic to deliver the message to
@@ -305,10 +305,10 @@ public:
 	 * @return token used to track and wait for the publish to complete. The
 	 *  	   token will be passed to callback methods if set.
 	 */
-	virtual idelivery_token_ptr publish(const std::string& topic,
+	idelivery_token_ptr publish(const std::string& topic,
 										const void* payload, size_t n,
 										int qos, bool retained, void* userContext,
-										iaction_listener& cb);
+										iaction_listener& cb) override;
 	/**
 	 * Publishes a message to a topic on the server Takes an Message
 	 * message and delivers it to the server at the requested quality of
@@ -318,7 +318,7 @@ public:
 	 * @return token used to track and wait for the publish to complete. The
 	 *  	   token will be passed to callback methods if set.
 	 */
-	virtual idelivery_token_ptr publish(const std::string& topic, const_message_ptr msg);
+	idelivery_token_ptr publish(const std::string& topic, const_message_ptr msg) override;
 	/**
 	 * Publishes a message to a topic on the server.
 	 * @param topic the topic to deliver the message to
@@ -331,14 +331,14 @@ public:
 	 * @return token used to track and wait for the publish to complete. The
 	 *  	   token will be passed to callback methods if set.
 	 */
-	virtual idelivery_token_ptr publish(const std::string& topic, const_message_ptr msg,
-										void* userContext, iaction_listener& cb);
+	idelivery_token_ptr publish(const std::string& topic, const_message_ptr msg,
+										void* userContext, iaction_listener& cb) override;
 	/**
 	 * Sets a callback listener to use for events that happen
 	 * asynchronously.
 	 * @param cb callback which will be invoked for certain asynchronous events
 	 */
-	virtual void set_callback(callback& cb);
+	void set_callback(callback& cb) override;
 	/**
 	 * Subscribe to multiple topics, each of which may include wildcards.
 	 * @param topicFilters
@@ -350,8 +350,8 @@ public:
 	 * @return token used to track and wait for the subscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr subscribe(const topic_filter_collection& topicFilters,
-								 const qos_collection& qos);
+	itoken_ptr subscribe(const topic_filter_collection& topicFilters,
+								 const qos_collection& qos) override;
 	/**
 	 * Subscribes to multiple topics, each of which may include wildcards.
 	 * @param topicFilters
@@ -366,9 +366,9 @@ public:
 	 * @return token used to track and wait for the subscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr subscribe(const topic_filter_collection& topicFilters,
+	itoken_ptr subscribe(const topic_filter_collection& topicFilters,
 								 const qos_collection& qos,
-								 void* userContext, iaction_listener& cb);
+								 void* userContext, iaction_listener& cb) override;
 	/**
 	 * Subscribe to a topic, which may include wildcards.
 	 * @param topicFilter the topic to subscribe to, which can include
@@ -378,7 +378,7 @@ public:
 	 * @return token used to track and wait for the subscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr subscribe(const std::string& topicFilter, int qos);
+	itoken_ptr subscribe(const std::string& topicFilter, int qos) override;
 	/**
 	 * Subscribe to a topic, which may include wildcards.
 	 * @param topicFilter the topic to subscribe to, which can include
@@ -394,8 +394,8 @@ public:
 	 * @return token used to track and wait for the subscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr subscribe(const std::string& topicFilter, int qos,
-								 void* userContext, iaction_listener& cb);
+	itoken_ptr subscribe(const std::string& topicFilter, int qos,
+								 void* userContext, iaction_listener& cb) override;
 	/**
 	 * Requests the server unsubscribe the client from a topic.
 	 * @param topicFilter the topic to unsubscribe from. It must match a
@@ -403,7 +403,7 @@ public:
 	 * @return token used to track and wait for the unsubscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr unsubscribe(const std::string& topicFilter);
+	itoken_ptr unsubscribe(const std::string& topicFilter) override;
 	/**
 	 * Requests the server unsubscribe the client from one or more topics.
 	 * @param topicFilters one or more topics to unsubscribe from. Each
@@ -412,7 +412,7 @@ public:
 	 * @return token used to track and wait for the unsubscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr unsubscribe(const topic_filter_collection& topicFilters);
+	itoken_ptr unsubscribe(const topic_filter_collection& topicFilters) override;
 	/**
 	 * Requests the server unsubscribe the client from one or more topics.
 	 * @param topicFilters
@@ -423,8 +423,8 @@ public:
 	 * @return token used to track and wait for the unsubscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr unsubscribe(const topic_filter_collection& topicFilters,
-								   void* userContext, iaction_listener& cb);
+	itoken_ptr unsubscribe(const topic_filter_collection& topicFilters,
+								   void* userContext, iaction_listener& cb) override;
 	/**
 	 * Requests the server unsubscribe the client from a topics.
 	 * @param topicFilter the topic to unsubscribe from. It must match a
@@ -436,8 +436,8 @@ public:
 	 * @return token used to track and wait for the unsubscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr unsubscribe(const std::string& topicFilter,
-								   void* userContext, iaction_listener& cb);
+	itoken_ptr unsubscribe(const std::string& topicFilter,
+								   void* userContext, iaction_listener& cb) override;
 };
 
 /** Smart/shared pointer to an asynchronous MQTT client object */

--- a/src/mqtt/delivery_token.h
+++ b/src/mqtt/delivery_token.h
@@ -28,37 +28,12 @@ extern "C" {
 	#include "MQTTAsync.h"
 }
 
+#include "mqtt/idelivery_token.h"
 #include "mqtt/token.h"
 #include "mqtt/message.h"
 #include <memory>
 
 namespace mqtt {
-
-/////////////////////////////////////////////////////////////////////////////
-
-/**
- * Provides a mechanism for tracking the delivery of a message.
- */
-class idelivery_token : public virtual itoken
-{
-public:
-	/** Smart/shared pointer to an object of this class */
-	using ptr_t = std::shared_ptr<idelivery_token>;
-	/** Smart/shared pointer to a const object of this class */
-	using const_ptr_t = std::shared_ptr<const idelivery_token>;
-
-	/**
-	 * Gets the message associated with this token.
-	 * @return The message associated with this token.
-	 */
-	virtual const_message_ptr get_message() const =0;
-};
-
-/** Smart/shared pointer to a delivery token */
-using idelivery_token_ptr = idelivery_token::ptr_t;
-
-/** Smart/shared pointer to a const delivery token */
-using const_idelivery_token_ptr = idelivery_token::const_ptr_t;
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/mqtt/exception.h
+++ b/src/mqtt/exception.h
@@ -72,7 +72,7 @@ public:
 	 * Returns an explanatory string for the exception.
 	 * @return const char* 
 	 */
-	virtual const char* what() const noexcept {
+	const char* what() const noexcept override {
 		return msg_.c_str();
 	}
 };

--- a/src/mqtt/idelivery_token.h
+++ b/src/mqtt/idelivery_token.h
@@ -1,0 +1,68 @@
+/////////////////////////////////////////////////////////////////////////////
+/// @file delivery_token.h
+/// Declaration of MQTT idelivery_token abstract class
+/// @date Feb 2, 2017
+/// @author Guilherme Maciel Ferreira
+/////////////////////////////////////////////////////////////////////////////
+
+/*******************************************************************************
+ * Copyright (c) 2017 Guilherme M. Ferreira <guilherme.maciel.ferreira@gmail.com>
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Guilherme M. Ferreira - split from delivery_token header
+ *******************************************************************************/
+
+#ifndef __mqtt_idelivery_token_h
+#define __mqtt_idelivery_token_h
+
+extern "C" {
+	#include "MQTTAsync.h"
+}
+
+#include "mqtt/token.h"
+#include "mqtt/message.h"
+#include <memory>
+
+namespace mqtt {
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Provides a mechanism for tracking the delivery of a message.
+ */
+class idelivery_token : public virtual itoken
+{
+public:
+	/** Smart/shared pointer to an object of this class */
+	using ptr_t = std::shared_ptr<idelivery_token>;
+	/** Smart/shared pointer to a const object of this class */
+	using const_ptr_t = std::shared_ptr<const idelivery_token>;
+
+	/**
+	 * Gets the message associated with this token.
+	 * @return The message associated with this token.
+	 */
+	virtual const_message_ptr get_message() const =0;
+};
+
+/** Smart/shared pointer to a delivery token */
+using idelivery_token_ptr = idelivery_token::ptr_t;
+
+/** Smart/shared pointer to a const delivery token */
+using const_idelivery_token_ptr = idelivery_token::const_ptr_t;
+
+/////////////////////////////////////////////////////////////////////////////
+// end namespace mqtt
+}
+
+#endif		// __mqtt_idelivery_token_h
+

--- a/src/mqtt/itoken.h
+++ b/src/mqtt/itoken.h
@@ -1,0 +1,117 @@
+/////////////////////////////////////////////////////////////////////////////
+/// @file itoken.h
+/// Declaration of MQTT token abstract class
+/// @date Oct 7, 2016
+/// @author Guilherme M. Ferreira
+/////////////////////////////////////////////////////////////////////////////
+
+/*******************************************************************************
+ * Copyright (c) 2016 Guilherme M. Ferreira <guilherme.maciel.ferreira@gmail.com>
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Guilherme M. Ferreira - split from token.h header
+ *******************************************************************************/
+
+#ifndef __mqtt_itoken_h
+#define __mqtt_itoken_h
+
+extern "C" {
+	#include "MQTTAsync.h"
+}
+
+#include "mqtt/iaction_listener.h"
+#include "mqtt/exception.h"
+#include <string>
+#include <vector>
+#include <memory>
+
+namespace mqtt {
+
+class iasync_client;
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Provides a mechanism for tracking the completion of an asynchronous task.
+ */
+class itoken
+{
+public:
+	/** Shared pointer to a token */
+	using ptr_t = std::shared_ptr<itoken>;
+	/**
+	 * Virtual base destructor.
+	 */
+	virtual ~itoken() {}
+	/**
+	 * Return the async listener for this token.
+	 * @return iaction_listener
+	 */
+	virtual iaction_listener* get_action_callback() const =0;
+	/**
+	 * Returns the MQTT client that is responsible for processing the
+	 * asynchronous action.
+	 * @return iasync_client
+	 */
+	virtual iasync_client* get_client() const =0;
+	/**
+	 * Returns the message ID of the message that is associated with the
+	 * token.
+	 * @return int
+	 */
+	virtual int get_message_id() const =0;
+	/**
+	 * Returns the topic string(s) for the action being tracked by this
+	 * token.
+	 * @return std::vector<std::string>
+	 */
+	virtual const std::vector<std::string>& get_topics() const =0;
+	/**
+	 * Retrieve the context associated with an action.
+	 * @return void*
+	 */
+	virtual void* get_user_context() const =0;
+	/**
+	 * Returns whether or not the action has finished.
+	 * @return bool
+	 */
+	virtual bool is_complete() const =0;
+	/**
+	 * Register a listener to be notified when an action completes.
+	 * @param listener
+	 */
+	virtual void set_action_callback(iaction_listener& listener) =0;
+	/**
+	 * Store some context associated with an action.
+	 * @param userContext
+	 */
+	virtual void set_user_context(void* userContext) =0;
+	/**
+	 * Blocks the current thread until the action this token is associated
+	 * with has completed.
+	 */
+	virtual void wait_for_completion() =0;
+	/**
+	 * Blocks the current thread until the action this token is associated
+	 * with has completed.
+	 * @param timeout The timeout (in milliseconds)
+	 */
+	virtual void wait_for_completion(long timeout) =0;
+};
+
+using itoken_ptr = itoken::ptr_t;
+
+/////////////////////////////////////////////////////////////////////////////
+// end namespace mqtt
+}
+
+#endif		// __mqtt_itoken_h

--- a/src/mqtt/token.h
+++ b/src/mqtt/token.h
@@ -28,6 +28,7 @@ extern "C" {
 	#include "MQTTAsync.h"
 }
 
+#include "mqtt/itoken.h"
 #include "mqtt/iaction_listener.h"
 #include "mqtt/exception.h"
 #include <string>
@@ -41,83 +42,6 @@ extern "C" {
 namespace mqtt {
 
 class iasync_client;
-
-/////////////////////////////////////////////////////////////////////////////
-
-/**
- * Provides a mechanism for tracking the completion of an asynchronous task.
- */
-class itoken
-{
-public:
-	/** Shared pointer to a token */
-	using ptr_t = std::shared_ptr<itoken>;
-	/**
-	 * Virtual base destructor.
-	 */
-	virtual ~itoken() {}
-	/**
-	 * Return the async listener for this token.
-	 * @return iaction_listener
-	 */
-	virtual iaction_listener* get_action_callback() const =0;
-	/**
-	 * Returns the MQTT client that is responsible for processing the
-	 * asynchronous action.
-	 * @return iasync_client
-	 */
-	virtual iasync_client* get_client() const =0;
-	/**
-	 * Returns an exception providing more detail if an operation failed.
-	 * @return Exception
-	 */
-	//virtual exception get_exception() =0;
-	/**
-	 * Returns the message ID of the message that is associated with the
-	 * token.
-	 * @return int
-	 */
-	virtual int get_message_id() const =0;
-	/**
-	 * Returns the topic string(s) for the action being tracked by this
-	 * token.
-	 * @return std::vector<std::string>
-	 */
-	virtual const std::vector<std::string>& get_topics() const =0;
-	/**
-	 * Retrieve the context associated with an action.
-	 * @return void*
-	 */
-	virtual void* get_user_context() const =0;
-	/**
-	 * Returns whether or not the action has finished.
-	 * @return bool
-	 */
-	virtual bool is_complete() const =0;
-	/**
-	 * Register a listener to be notified when an action completes.
-	 * @param listener
-	 */
-	virtual void set_action_callback(iaction_listener& listener) =0;
-	/**
-	 * Store some context associated with an action.
-	 * @param userContext
-	 */
-	virtual void set_user_context(void* userContext) =0;
-	/**
-	 * Blocks the current thread until the action this token is associated
-	 * with has completed.
-	 */
-	virtual void wait_for_completion() =0;
-	/**
-	 * Blocks the current thread until the action this token is associated
-	 * with has completed.
-	 * @param timeout
-	 */
-	virtual void wait_for_completion(long timeout) =0;
-};
-
-using itoken_ptr = itoken::ptr_t;
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/mqtt/token.h
+++ b/src/mqtt/token.h
@@ -156,7 +156,7 @@ public:
 	 * Return the async listener for this token.
 	 * @return iaction_listener
 	 */
-	virtual iaction_listener* get_action_callback() const {
+	iaction_listener* get_action_callback() const override {
 		// TODO: Guard?
 		return listener_;
 	}
@@ -165,20 +165,15 @@ public:
 	 * asynchronous action.
 	 * @return iasync_client
 	 */
-	virtual iasync_client* get_client() const {
+	iasync_client* get_client() const override {
 		return cli_;
 	}
-	/**
-	 * Returns an exception providing more detail if an operation failed.
-	 * @return Exception
-	 */
-	//virtual exception get_exception();
 	/**
 	 * Returns the message ID of the message that is associated with the
 	 * token.
 	 * @return int
 	 */
-	virtual int get_message_id() const {
+	int get_message_id() const override {
 		static_assert(sizeof(tok_) == sizeof(int), "MQTTAsync_token must fit into int");
 		return static_cast<int>(tok_);
 	}
@@ -186,13 +181,13 @@ public:
 	 * Returns the topic string(s) for the action being tracked by this
 	 * token.
 	 */
-	virtual const std::vector<std::string>& get_topics() const {
+	const std::vector<std::string>& get_topics() const override {
 		return topics_;
 	}
 	/**
 	 * Retrieve the context associated with an action.
 	 */
-	virtual void* get_user_context() const {
+	void* get_user_context() const override {
 		guard g(lock_);
 		return userContext_;
 	}
@@ -200,12 +195,12 @@ public:
 	 * Returns whether or not the action has finished.
 	 * @return bool
 	 */
-	virtual bool is_complete() const { return complete_; }
+	bool is_complete() const override { return complete_; }
 	/**
 	 * Register a listener to be notified when an action completes.
 	 * @param listener
 	 */
-	virtual void set_action_callback(iaction_listener& listener) {
+	void set_action_callback(iaction_listener& listener) override {
 		guard g(lock_);
 		listener_ = &listener;
 	}
@@ -213,7 +208,7 @@ public:
 	 * Store some context associated with an action.
 	 * @param userContext
 	 */
-	virtual void set_user_context(void* userContext) {
+	void set_user_context(void* userContext) override {
 		guard g(lock_);
 		userContext_ = userContext;
 	}
@@ -221,13 +216,13 @@ public:
 	 * Blocks the current thread until the action this token is associated
 	 * with has completed.
 	 */
-	virtual void wait_for_completion();
+	void wait_for_completion() override;
 	/**
 	 * Blocks the current thread until the action this token is associated
 	 * with has completed.
 	 * @param timeout The timeout (in milliseconds)
 	 */
-	virtual void wait_for_completion(long timeout);
+	void wait_for_completion(long timeout) override;
 	/**
 	 * Waits a relative amount of time for the action to complete.
 	 * @param relTime The amount of time to wait for the event.

--- a/src/samples/async_publish.cpp
+++ b/src/samples/async_publish.cpp
@@ -49,16 +49,16 @@ inline void sleep(int ms) {
 class callback : public virtual mqtt::callback
 {
 public:
-	virtual void connection_lost(const std::string& cause) {
+	void connection_lost(const std::string& cause) override {
 		std::cout << "\nConnection lost" << std::endl;
 		if (!cause.empty())
 			std::cout << "\tcause: " << cause << std::endl;
 	}
 
 	// We're not subscribed to anything, so this should never be called.
-	virtual void message_arrived(const std::string& topic, mqtt::const_message_ptr msg) {}
+	void message_arrived(const std::string& topic, mqtt::const_message_ptr msg) override {}
 
-	virtual void delivery_complete(mqtt::idelivery_token_ptr tok) {
+	void delivery_complete(mqtt::idelivery_token_ptr tok) override {
 		std::cout << "Delivery complete for token: "
 			<< (tok ? tok->get_message_id() : -1) << std::endl;
 	}
@@ -72,12 +72,12 @@ public:
 class action_listener : public virtual mqtt::iaction_listener
 {
 protected:
-	virtual void on_failure(const mqtt::itoken& tok) {
+	void on_failure(const mqtt::itoken& tok) override {
 		std::cout << "\n\tListener: Failure on token: "
 			<< tok.get_message_id() << std::endl;
 	}
 
-	virtual void on_success(const mqtt::itoken& tok) {
+	void on_success(const mqtt::itoken& tok) override {
 		std::cout << "\n\tListener: Success on token: "
 			<< tok.get_message_id() << std::endl;
 	}
@@ -92,12 +92,12 @@ class delivery_action_listener : public action_listener
 {
 	bool done_;
 
-	virtual void on_failure(const mqtt::itoken& tok) {
+	void on_failure(const mqtt::itoken& tok) override {
 		action_listener::on_failure(tok);
 		done_ = true;
 	}
 
-	virtual void on_success(const mqtt::itoken& tok) {
+	void on_success(const mqtt::itoken& tok) override {
 		action_listener::on_success(tok);
 		done_ = true;
 	}

--- a/src/samples/async_subscribe.cpp
+++ b/src/samples/async_subscribe.cpp
@@ -36,14 +36,14 @@ class action_listener : public virtual mqtt::iaction_listener
 {
 	std::string name_;
 
-	virtual void on_failure(const mqtt::itoken& tok) {
+	void on_failure(const mqtt::itoken& tok) override {
 		std::cout << name_ << " failure";
 		if (tok.get_message_id() != 0)
 			std::cout << " for token: [" << tok.get_message_id() << "]" << std::endl;
 		std::cout << std::endl;
 	}
 
-	virtual void on_success(const mqtt::itoken& tok) {
+	void on_success(const mqtt::itoken& tok) override {
 		std::cout << name_ << " success";
 		if (tok.get_message_id() != 0)
 			std::cout << " for token: [" << tok.get_message_id() << "]" << std::endl;
@@ -85,7 +85,7 @@ class callback : public virtual mqtt::callback,
 	}
 
 	// Re-connection failure
-	virtual void on_failure(const mqtt::itoken& tok) {
+	void on_failure(const mqtt::itoken& tok) override {
 		std::cout << "Connection failed" << std::endl;
 		if (++nretry_ > 5)
 			exit(1);
@@ -93,7 +93,7 @@ class callback : public virtual mqtt::callback,
 	}
 
 	// Re-connection success
-	virtual void on_success(const mqtt::itoken& tok) {
+	void on_success(const mqtt::itoken& tok) override {
 		std::cout << "\nConnection success" << std::endl;
 		std::cout << "\nSubscribing to topic '" << TOPIC << "'\n"
 			<< "\tfor client " << CLIENTID
@@ -103,7 +103,7 @@ class callback : public virtual mqtt::callback,
 		cli_.subscribe(TOPIC, QOS, nullptr, subListener_);
 	}
 
-	virtual void connection_lost(const std::string& cause) {
+	void connection_lost(const std::string& cause) override {
 		std::cout << "\nConnection lost" << std::endl;
 		if (!cause.empty())
 			std::cout << "\tcause: " << cause << std::endl;
@@ -113,13 +113,13 @@ class callback : public virtual mqtt::callback,
 		reconnect();
 	}
 
-	virtual void message_arrived(const std::string& topic, mqtt::const_message_ptr msg) {
+	void message_arrived(const std::string& topic, mqtt::const_message_ptr msg) override {
 		std::cout << "Message arrived" << std::endl;
 		std::cout << "\ttopic: '" << topic << "'" << std::endl;
 		std::cout << "\t'" << msg->to_str() << "'\n" << std::endl;
 	}
 
-	virtual void delivery_complete(mqtt::idelivery_token_ptr token) {}
+	void delivery_complete(mqtt::idelivery_token_ptr token) override {}
 
 public:
 	callback(mqtt::async_client& cli, mqtt::connect_options& connOpts)

--- a/src/samples/sync_publish.cpp
+++ b/src/samples/sync_publish.cpp
@@ -55,31 +55,31 @@ public:
 	sample_mem_persistence() : open_(false) {}
 
 	// "Open" the store
-	virtual void open(const std::string& clientId, const std::string& serverURI) {
+	void open(const std::string& clientId, const std::string& serverURI) override {
 		std::cout << "[Opening persistence store for '" << clientId
 			<< "' at '" << serverURI << "']" << std::endl;
 		open_ = true;
 	}
 
 	// Close the persistent store that was previously opened.
-	virtual void close() {
+	void close() override {
 		std::cout << "[Closing persistence store.]" << std::endl;
 		open_ = false;
 	}
 
 	// Clears persistence, so that it no longer contains any persisted data.
-	virtual void clear() {
+	void clear() override {
 		std::cout << "[Clearing persistence store.]" << std::endl;
 		store_.clear();
 	}
 
 	// Returns whether or not data is persisted using the specified key.
-	virtual bool contains_key(const std::string &key) {
+	bool contains_key(const std::string &key) override {
 		return store_.find(key) != store_.end();
 	}
 
 	// Gets the specified data out of the persistent store.
-	virtual mqtt::ipersistable_ptr get(const std::string& key) const {
+	mqtt::ipersistable_ptr get(const std::string& key) const override {
 		std::cout << "[Searching persistence for key '"
 			<< key << "']" << std::endl;
 		auto p = store_.find(key);
@@ -93,7 +93,7 @@ public:
 	/**
 	 * Returns the keys in this persistent data store.
 	 */
-	virtual std::vector<std::string> keys() const {
+	std::vector<std::string> keys() const override {
 		std::vector<std::string> ks;
 		for (const auto& k : store_)
 			ks.push_back(k.first);
@@ -101,7 +101,7 @@ public:
 	}
 
 	// Puts the specified data into the persistent store.
-	virtual void put(const std::string& key, mqtt::ipersistable_ptr persistable) {
+	void put(const std::string& key, mqtt::ipersistable_ptr persistable) override {
 		std::cout << "[Persisting data with key '"
 			<< key << "']" << std::endl;
 
@@ -109,7 +109,7 @@ public:
 	}
 
 	// Remove the data for the specified key.
-	virtual void remove(const std::string &key) {
+	void remove(const std::string &key) override {
 		std::cout << "[Persistence removing key '" << key << "']" << std::endl;
 		auto p = store_.find(key);
 		if (p == store_.end())
@@ -124,17 +124,17 @@ public:
 class callback : public virtual mqtt::callback
 {
 public:
-	virtual void connection_lost(const std::string& cause) {
+	void connection_lost(const std::string& cause) override {
 		std::cout << "\nConnection lost" << std::endl;
 		if (!cause.empty())
 			std::cout << "\tcause: " << cause << std::endl;
 	}
 
 	// We're not subscrived to anything, so this should never be called.
-	virtual void message_arrived(const std::string& topic,
-								 mqtt::const_message_ptr msg) {}
+	void message_arrived(const std::string& topic,
+								 mqtt::const_message_ptr msg) override {}
 
-	virtual void delivery_complete(mqtt::idelivery_token_ptr tok) {
+	void delivery_complete(mqtt::idelivery_token_ptr tok) override {
 		std::cout << "\n\t[Delivery complete for token: "
 			<< (tok ? tok->get_message_id() : -1) << "]" << std::endl;
 	}


### PR DESCRIPTION
Using "override" for inherited member functions. This keyword provides better check than virtual.
