### PR TITLE
Define literals as constant expressions

### DIFF
--- a/src/mqtt/async_client.h
+++ b/src/mqtt/async_client.h
@@ -44,9 +44,9 @@
 
 namespace mqtt {
 
-const uint32_t	VERSION = 0x00050000;
-const string	VERSION_STR("mqttpp v. 0.5"),
-				COPYRIGHT("Copyright (c) 2013-2016 Frank Pagliughi");
+constexpr const uint32_t	VERSION = 0x00050000;
+const string	VERSION_STR("mqttpp v. 0.5");
+const string	COPYRIGHT("Copyright (c) 2013-2016 Frank Pagliughi");
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/mqtt/client.h
+++ b/src/mqtt/client.h
@@ -148,11 +148,6 @@ public:
 		disconnect((int) to_milliseconds(to).count());
 	}
 	/**
-	 * Returns a randomly generated client identifier based on the current
-	 * user's login name and the system time.
-	 */
-	//static string generate_client_id();
-	/**
 	 * Returns the client ID used by this client.
 	 * @return string
 	 */

--- a/src/samples/async_publish.cpp
+++ b/src/samples/async_publish.cpp
@@ -30,14 +30,14 @@ const std::string DFLT_CLIENT_ID {"AsyncPublisher"};
 
 const string TOPIC {"hello"};
 
-const char* PAYLOAD1 = "Hello World!";
-const char* PAYLOAD2 = "Hi there!";
-const char* PAYLOAD3 = "Is anyone listening?";
-const char* PAYLOAD4 = "Someone is always listening.";
+constexpr const char* PAYLOAD1 = "Hello World!";
+constexpr const char* PAYLOAD2 = "Hi there!";
+constexpr const char* PAYLOAD3 = "Is anyone listening?";
+constexpr const char* PAYLOAD4 = "Someone is always listening.";
 
-const char* LWT_PAYLOAD = "Last will and testament.";
+constexpr const char* LWT_PAYLOAD = "Last will and testament.";
 
-const int  QOS = 1;
+constexpr int  QOS = 1;
 
 const auto TIMEOUT = std::chrono::seconds(10);
 

--- a/src/samples/async_subscribe.cpp
+++ b/src/samples/async_subscribe.cpp
@@ -27,7 +27,7 @@ const std::string ADDRESS("tcp://localhost:1883");
 const std::string CLIENTID("AsyncSubcriber");
 const std::string TOPIC("hello");
 
-const int  QOS = 1;
+constexpr int  QOS = 1;
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/samples/pub_speed_test.cpp
+++ b/src/samples/pub_speed_test.cpp
@@ -36,13 +36,13 @@ using namespace std::chrono;
 const std::string DFLT_ADDRESS {"tcp://localhost:1883"};
 const std::string CLIENT_ID {"pub_speed_test"};
 
-const size_t	DFLT_PAYLOAD_SIZE = 1024;
-const int		DFLT_N_MSG = 1000,
-				DFLT_QOS = 1;
+constexpr size_t	DFLT_PAYLOAD_SIZE = 1024;
+constexpr int		DFLT_N_MSG = 1000;
+constexpr int		DFLT_QOS = 1;
 
 const string TOPIC {"test/speed"};
 
-const char* LWT_PAYLOAD = "pub_speed_test died unexpectedly.";
+constexpr const char* LWT_PAYLOAD = "pub_speed_test died unexpectedly.";
 
 // Queue for passing tokens to the wait thread
 mqtt::thread_queue<mqtt::delivery_token_ptr> que;

--- a/src/samples/ssl_publish.cpp
+++ b/src/samples/ssl_publish.cpp
@@ -35,12 +35,12 @@ const std::string DFLT_CLIENT_ID {"CppAsyncPublisherSSL"};
 
 const std::string TOPIC {"hello"};
 
-const char* PAYLOAD1 = "Hello World!";
-const char* PAYLOAD2 = "Hi there!";
+constexpr const char* PAYLOAD1 = "Hello World!";
+constexpr const char* PAYLOAD2 = "Hi there!";
 
-const char* LWT_PAYLOAD = "Last will and testament.";
+constexpr const char* LWT_PAYLOAD = "Last will and testament.";
 
-const int  QOS = 1;
+constexpr int  QOS = 1;
 const auto TIMEOUT = std::chrono::seconds(10);
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/samples/sync_publish.cpp
+++ b/src/samples/sync_publish.cpp
@@ -33,10 +33,10 @@ const std::string TOPIC("hello");
 
 const std::string PAYLOAD1("Hello World!");
 
-const char* PAYLOAD2 = "Hi there!";
-const char* PAYLOAD3 = "Is anyone listening?";
+constexpr const char* PAYLOAD2 = "Hi there!";
+constexpr const char* PAYLOAD3 = "Is anyone listening?";
 
-const int QOS = 1;
+constexpr int QOS = 1;
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/test/unit/connect_options_test.h
+++ b/test/unit/connect_options_test.h
@@ -394,7 +394,7 @@ public:
 		const auto& c_struct = opts.opts_;
 
 		// Set as an int
-		const int TIMEOUT_SEC = 10;
+		constexpr int TIMEOUT_SEC = 10;
 		opts.set_connect_timeout(TIMEOUT_SEC);
 
 		CPPUNIT_ASSERT_EQUAL(TIMEOUT_SEC, (int) opts.get_connect_timeout().count());

--- a/test/unit/disconnect_options_test.h
+++ b/test/unit/disconnect_options_test.h
@@ -74,7 +74,7 @@ public:
 // ----------------------------------------------------------------------
 
 	void test_user_constructor() {
-		const int TIMEOUT = 10;
+		constexpr int TIMEOUT = 10;
 
 		auto tok = token::create(cli);
 		mqtt::disconnect_options opts { TIMEOUT, tok };
@@ -96,7 +96,7 @@ public:
 		mqtt::disconnect_options opts;
 		const auto& c_struct = opts.opts_;
 
-		const int TIMEOUT = 5000;	// ms
+		constexpr int TIMEOUT = 5000;	// ms
 
 		// Set with integer
 		opts.set_timeout(TIMEOUT);


### PR DESCRIPTION
Use constexpr for those constants that are evaluated at compile-time.
