### PR TITLE
Fix invalid memory reference in iclient_persistence::persistence_put()

### DIFF
--- a/src/iclient_persistence.cpp
+++ b/src/iclient_persistence.cpp
@@ -105,13 +105,13 @@ int iclient_persistence::persistence_put(void* handle, char* key, int bufcount,
 	try {
 		if (handle && bufcount > 0) {
 			ipersistable_ptr p;
+			std::string buf;
 			if (bufcount == 1)
 				p = std::make_shared<persistence_wrapper>(buffers[0], buflens[0]);
 			else if (bufcount == 2)
 				p = std::make_shared<persistence_wrapper>(buffers[0], buflens[0],
 														  buffers[1], buflens[1]);
 			else {
-				std::string buf;
 				for (int i=0; i<bufcount; ++i) {
 					if (buffers[i] && buflens[i] > 0)
 						buf.append(buffers[i], buflens[i]);


### PR DESCRIPTION
In the method `iclient_persistence::persistence_put()`, the `buf` string's internal array (1) is referenced by `p` (2). However, `buf` is not in the stack anymore when it is later referenced indirectly by the method `iclient_persistence::put()` (3).

```
  {
    std::string buf; // (1)
    ...
    p = std::make_shared<persistence_wrapper>(&buf[0], buf.size()); // (2)
  }
  static_cast<iclient_persistence*>(handle)->put(key, p); // (3)
```

The simplest solution is to put `buf` in the same scope as the last method that references it (3). So we don't risk to get `buf` removed from stack before it is used by the last time:

```
  std::string buf;
  {
    ...
    p = std::make_shared<persistence_wrapper>(&buf[0], buf.size());
  }
  static_cast<iclient_persistence*>(handle)->put(key, p);
```

Signed-off-by: Guilherme Maciel Ferreira <guilherme.maciel.ferreira@gmail.com>