### PR TITLE
Class Connect Options initializes its own callback functions

### DIFF
--- a/src/connect_options.cpp
+++ b/src/connect_options.cpp
@@ -27,6 +27,8 @@ connect_options::connect_options()
 #if defined(OPENSSL)
 	opts_.ssl = nullptr;
 #endif
+	opts_.onSuccess = &token::on_success;
+	opts_.onFailure = &token::on_failure;
 }
 
 connect_options::connect_options(const std::string& userName, const std::string& password)

--- a/src/mqtt/token.h
+++ b/src/mqtt/token.h
@@ -154,7 +154,6 @@ class token : public virtual itoken
 	int rc_;
 
 	/** Client and token-related options have special access */
-	friend class async_client;
 	friend class response_options;
 	friend class delivery_response_options;
 	friend class connect_options;


### PR DESCRIPTION
Like the other options classes (`response_options`, `disconnect_options` and `delivery_response_options`), the `connect_options` initializes its token callback funtions instead of relying on `async_client` class to do it.