### PR TITLE
Fix get_time_to_wait() return type

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -92,7 +92,7 @@ std::vector<idelivery_token_ptr> client::get_pending_delivery_tokens() const
 	return cli_.get_pending_delivery_tokens();
 }
 
-long client::get_time_to_wait() const
+int client::get_time_to_wait() const
 {
 	return timeout_;
 }

--- a/src/mqtt/client.h
+++ b/src/mqtt/client.h
@@ -136,9 +136,9 @@ public:
 	virtual std::string get_server_uri() const;
 	/**
 	 * Return the maximum time to wait for an action to complete.
-	 * @return long
+	 * @return int
 	 */
-	virtual long get_time_to_wait() const;
+	virtual int get_time_to_wait() const;
 	/**
 	 * Get a topic object which can be used to publish messages.
 	 * @param tpc


### PR DESCRIPTION
The member variable `timeout_` is `int` as well as the `set_time_to_wait()`. Thus there's no reason for the `get_time_to_wait()` to return a different type.