### PR TITLE
Add test and coverage targets to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 lib/
 \.hg/
 \.hgignore
+\test/unit/mqttpp-unittest
 .deps/
 .libs/
 *.vp*

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ all: $(TGT) $(LIB_DIR)/$(LIB_LINK) $(LIB_DIR)/$(LIB_MAJOR_LINK)
 
 $(TGT): $(OBJS)
 	@echo Creating library: $@
-	$(QUIET) $(CC) $(LDFLAGS) -o $@ $^ $(LIB_DEP_FLAGS)
+	$(QUIET) $(CXX) $(LDFLAGS) -o $@ $^ $(LIB_DEP_FLAGS)
 
 $(LIB_DIR)/$(LIB_MAJOR_LINK): $(TGT)
 	$(QUIET) cd $(LIB_DIR) ; $(RM) $(LIB_MAJOR_LINK) ; ln -s $(LIB) $(LIB_MAJOR_LINK)

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,11 @@ OBJ_DIR ?= $(CROSS_COMPILE)obj
 
 ifdef DEVELOP
   PAHO_C_DIR := $(abspath ../paho.mqtt.c)
+  PAHO_C_LIB_DIR ?= $(PAHO_C_DIR)/build/output
   PAHO_C_INC_DIR ?= $(PAHO_C_DIR)/src
+else
+  PAHO_C_LIB_DIR ?= /usr/local/lib
+  PAHO_C_INC_DIR ?= /usr/local/include
 endif
 
 vpath %.cpp $(SRC_DIR)
@@ -110,9 +114,7 @@ LIB_DEP_FLAGS += $(addprefix -l,$(LIB_DEPS))
 
 LDFLAGS := -g -shared -Wl,-soname,$(LIB_MAJOR_LINK) -L$(LIB_DIR)
 
-ifdef DEVELOP
-  LDFLAGS += -L$(PAHO_C_DIR)/build/output
-endif
+LDFLAGS += -L$(PAHO_C_LIB_DIR)
 
 
 # ----- Compiler directives -----

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,8 @@ TEST_DIR ?= test
 LIB_DIR ?= $(CROSS_COMPILE)lib
 OBJ_DIR ?= $(CROSS_COMPILE)obj
 
+COV_DIR ?= $(CROSS_COMPILE)cov
+
 ifdef DEVELOP
   PAHO_C_DIR := $(abspath ../paho.mqtt.c)
   PAHO_C_LIB_DIR ?= $(PAHO_C_DIR)/build/output
@@ -117,6 +119,10 @@ LDFLAGS := -g -shared -Wl,-soname,$(LIB_MAJOR_LINK) -L$(LIB_DIR)
 
 LDFLAGS += -L$(PAHO_C_LIB_DIR)
 
+ifdef COVERAGE
+  CXXFLAGS += -fprofile-arcs -ftest-coverage
+  LDFLAGS += -fprofile-arcs -pg -lgcov
+endif
 
 # ----- Compiler directives -----
 
@@ -171,6 +177,13 @@ samples: $(SRC_DIR)/samples $(LIB_DIR)/$(LIB_LINK)
 .PHONY: check
 check: $(TEST_DIR)/unit $(LIB_DIR)/$(LIB_LINK)
 	$(MAKE) -C $<
+
+.PHONY: coverage
+coverage:
+	$(MAKE) COVERAGE=1 test
+	lcov --directory $(OBJ_DIR) --base-directory ./ --capture --output-file coverage.info
+	genhtml coverage.info -o $(COV_DIR)
+	firefox $(COV_DIR)/index.html
 
 # ----- Installation targets -----
 

--- a/Makefile
+++ b/Makefile
@@ -130,11 +130,11 @@ $(TGT): $(OBJS)
 	@echo Creating library: $@
 	$(QUIET) $(CC) $(LDFLAGS) -o $@ $^ $(LIB_DEP_FLAGS)
 
-$(LIB_DIR)/$(LIB_LINK): $(LIB_DIR)/$(LIB_MAJOR_LINK)
-	$(QUIET) cd $(LIB_DIR) ; $(RM) $(LIB_LINK) ; ln -s $(LIB_MAJOR_LINK) $(LIB_LINK)
-
 $(LIB_DIR)/$(LIB_MAJOR_LINK): $(TGT)
 	$(QUIET) cd $(LIB_DIR) ; $(RM) $(LIB_MAJOR_LINK) ; ln -s $(LIB) $(LIB_MAJOR_LINK)
+
+$(LIB_DIR)/$(LIB_LINK): $(LIB_DIR)/$(LIB_MAJOR_LINK)
+	$(QUIET) cd $(LIB_DIR) ; $(RM) $(LIB_LINK) ; ln -s $(LIB_MAJOR_LINK) $(LIB_LINK)
 
 .PHONY: dump
 dump:
@@ -162,7 +162,7 @@ distclean: clean
 	$(QUIET) rm -rf $(OBJ_DIR) $(LIB_DIR)
 
 .PHONY: samples
-samples: $(SRC_DIR)/samples
+samples: $(SRC_DIR)/samples $(LIB_DIR)/$(LIB_LINK)
 	$(MAKE) -C $<
 
 # ----- Installation targets -----

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ INSTALL_DATA =  $(INSTALL) -m 644
 
 SRC_DIR ?= src
 INC_DIR ?= src
+TEST_DIR ?= test
 
 LIB_DIR ?= $(CROSS_COMPILE)lib
 OBJ_DIR ?= $(CROSS_COMPILE)obj
@@ -167,6 +168,10 @@ distclean: clean
 samples: $(SRC_DIR)/samples $(LIB_DIR)/$(LIB_LINK)
 	$(MAKE) -C $<
 
+.PHONY: check
+check: $(TEST_DIR)/unit $(LIB_DIR)/$(LIB_LINK)
+	$(MAKE) -C $<
+
 # ----- Installation targets -----
 
 strip_options:
@@ -196,4 +201,3 @@ $(OBJ_DIR)/%.dep: %.cpp
 	$(QUIET) $(CXX) -M $(CPPFLAGS) $(CXXFLAGS) $< > $@.$$$$; \
 	sed 's,\($*\)\.o[ :]*,$$(OBJ_DIR)/\1.o $@ : ,g' < $@.$$$$ > $@; \
 	$(RM) $@.$$$$
-

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -45,13 +45,18 @@ else
   PAHO_C_LIB ?= paho-mqtt3a
 endif
 
+ifdef COVERAGE
+  CXXFLAGS += -fprofile-arcs -ftest-coverage
+  LDFLAGS += -fprofile-arcs -pg -lgcov
+endif
+
 LDLIBS += -L$(PAHO_CPP_LIB_DIR) -lpaho-mqttpp3
 LDLIBS += -L$(PAHO_C_LIB_DIR) -l$(PAHO_C_LIB)
 LDLIBS += -lcppunit
 LDLIBS += -ldl
 
 $(TGT): test.cpp $(HDR_TESTS)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ $< $(LDLIBS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ $< $(LDLIBS) $(LDFLAGS)
 
 run: $(TGT)
 	LD_LIBRARY_PATH=$(PAHO_C_LIB_DIR):$(PAHO_CPP_LIB_DIR) ./$(TGT)

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -1,10 +1,12 @@
 # Makefile for the paho-mqttpp (C++) unit tests
 
 ifdef DEVELOP
+  PAHO_CPP_LIB_DIR ?= $(abspath ../..)/lib
   PAHO_C_DIR ?= $(abspath ../../../paho.mqtt.c)
   PAHO_C_LIB_DIR ?= $(PAHO_C_DIR)/build/output
   PAHO_C_INC_DIR ?= $(PAHO_C_DIR)/src
 else
+  PAHO_CPP_LIB_DIR ?= /usr/local/lib
   PAHO_C_LIB_DIR ?= /usr/local/lib
   PAHO_C_INC_DIR ?= /usr/local/include
 endif
@@ -41,7 +43,10 @@ else
   PAHO_C_LIB ?= paho-mqtt3a
 endif
 
-LDLIBS += -L../../lib -L$(PAHO_C_LIB_DIR) -lpaho-mqttpp3 -l$(PAHO_C_LIB) -lcppunit -ldl
+LDLIBS += -L$(PAHO_CPP_LIB_DIR) -lpaho-mqttpp3
+LDLIBS += -L$(PAHO_C_LIB_DIR) -l$(PAHO_C_LIB)
+LDLIBS += -lcppunit
+LDLIBS += -ldl
 
 $(TGT): test.cpp $(HDR_TESTS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ $< $(LDLIBS)
@@ -57,6 +62,3 @@ distclean: clean
 dump:
 	@echo CXX: $(CXX)
 	@echo Tests: $(HDR_TESTS)
-
-
-

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -16,7 +16,7 @@ PAHO_CPP_INC_DIR ?= $(abspath ../..)/src
 TGT = mqttpp-unittest
 
 .PHONY: all
-all: $(TGT)
+all: $(TGT) run
 
 ifneq ($(CROSS_COMPILE),)
   CC  = $(CROSS_COMPILE)gcc
@@ -53,6 +53,8 @@ LDLIBS += -ldl
 $(TGT): test.cpp $(HDR_TESTS)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o $@ $< $(LDLIBS)
 
+run: $(TGT)
+	LD_LIBRARY_PATH=$(PAHO_C_LIB_DIR):$(PAHO_CPP_LIB_DIR) ./$(TGT)
 
 .PHONY: clean distclean dump
 

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -11,6 +11,8 @@ else
   PAHO_C_INC_DIR ?= /usr/local/include
 endif
 
+PAHO_CPP_INC_DIR ?= $(abspath ../..)/src
+
 TGT = mqttpp-unittest
 
 .PHONY: all
@@ -26,7 +28,7 @@ endif
 HDR_TESTS = $(wildcard *.h)
 
 CXXFLAGS += -Wall -std=c++11
-CPPFLAGS += -I../../src -I$(PAHO_C_INC_DIR)
+CPPFLAGS += -I$(PAHO_CPP_INC_DIR) -I$(PAHO_C_INC_DIR)
 
 ifdef DEBUG
   CPPFLAGS += -DDEBUG


### PR DESCRIPTION
This set of changes adds targets to the Makefile to execute unit tests and code coverage.