### PR TITLE
Use proper Message ID's

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,7 @@ lib_LTLIBRARIES  = libpaho-mqttpp3.la
 
 libpaho_mqttpp3_la_SOURCES  = src/async_client.cpp
 libpaho_mqttpp3_la_SOURCES += src/client.cpp
+libpaho_mqttpp3_la_SOURCES += src/delivery_response_options.cpp
 libpaho_mqttpp3_la_SOURCES += src/disconnect_options.cpp
 libpaho_mqttpp3_la_SOURCES += src/iclient_persistence.cpp
 libpaho_mqttpp3_la_SOURCES += src/message.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,6 +38,7 @@ endif()
 set(COMMON_SRC
     async_client.cpp
     client.cpp
+    delivery_response_options.cpp
     disconnect_options.cpp
     iclient_persistence.cpp
     message.cpp

--- a/src/async_client.cpp
+++ b/src/async_client.cpp
@@ -20,6 +20,7 @@
 #include "mqtt/token.h"
 #include "mqtt/message.h"
 #include "mqtt/response_options.h"
+#include "mqtt/delivery_response_options.h"
 #include "mqtt/disconnect_options.h"
 #include <thread>
 #include <mutex>
@@ -598,4 +599,3 @@ itoken_ptr async_client::unsubscribe(const std::string& topicFilter,
 /////////////////////////////////////////////////////////////////////////////
 // end namespace mqtt
 }
-

--- a/src/async_client.cpp
+++ b/src/async_client.cpp
@@ -113,8 +113,8 @@ int async_client::on_message_arrived(void* context, char* topicName, int topicLe
 		}
 	}
 
-    MQTTAsync_freeMessage(&msg);
-    MQTTAsync_free(topicName);
+	MQTTAsync_freeMessage(&msg);
+	MQTTAsync_free(topicName);
 
 	// TODO: Should the user code determine the return value?
 	// The Java version does doesn't seem to...
@@ -160,8 +160,8 @@ void async_client::add_token(itoken_ptr tok)
 void async_client::add_token(idelivery_token_ptr tok)
 {
 	if (tok) {
-	   guard g(lock_);
-	   pendingDeliveryTokens_.push_back(tok);
+		guard g(lock_);
+		pendingDeliveryTokens_.push_back(tok);
 	}
 }
 
@@ -367,6 +367,8 @@ idelivery_token_ptr async_client::publish(const std::string& topic, const_messag
 
 	int rc = MQTTAsync_sendMessage(cli_, topic.c_str(), &(msg->msg_),
 								   &opts.opts_);
+
+	opts.update_message_id();
 
 	if (rc != MQTTASYNC_SUCCESS) {
 		remove_token(tok);

--- a/src/delivery_response_options.cpp
+++ b/src/delivery_response_options.cpp
@@ -19,6 +19,17 @@ delivery_response_options::delivery_response_options(const delivery_token_ptr& t
 	set_token(tok);
 }
 
+void delivery_response_options::update_message_id()
+{
+	if (opts_.context) {
+		delivery_token* dtok { reinterpret_cast<delivery_token*>(opts_.context) };
+		token* tok { dynamic_cast<token*>(dtok) };
+		if (tok) {
+			tok->tok_ = opts_.token;
+		}
+	}
+}
+
 /////////////////////////////////////////////////////////////////////////////
 // end namespace 'mqtt'
 }

--- a/src/delivery_response_options.cpp
+++ b/src/delivery_response_options.cpp
@@ -1,0 +1,24 @@
+// delivery_response_options.cpp
+
+#include "mqtt/delivery_response_options.h"
+
+namespace mqtt {
+
+/////////////////////////////////////////////////////////////////////////////
+
+delivery_response_options::delivery_response_options()
+		: opts_(MQTTAsync_responseOptions_initializer)
+{
+	opts_.onSuccess = &delivery_token::on_success;
+	opts_.onFailure = &delivery_token::on_failure;
+}
+
+delivery_response_options::delivery_response_options(const delivery_token_ptr& tok)
+		: delivery_response_options()
+{
+	set_token(tok);
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// end namespace 'mqtt'
+}

--- a/src/mqtt/delivery_response_options.h
+++ b/src/mqtt/delivery_response_options.h
@@ -53,6 +53,14 @@ public:
 		dtok_ = dtok;
 		opts_.context = dtok.get();
 	}
+
+	/**
+	 * Synchronize the token's (context) message ID with the message ID from
+	 * delivery_response_options. Because the delivery_response_options's message
+	 * ID is updated by the Paho MQTT C right after the message is sent, but the
+	 * token's message ID is updated only after the response arrives.
+	 */
+	void update_message_id();
 };
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/mqtt/delivery_response_options.h
+++ b/src/mqtt/delivery_response_options.h
@@ -1,0 +1,62 @@
+/////////////////////////////////////////////////////////////////////////////
+/// @file delivery_response_options.h
+/// Implementation of the class 'delivery_response_options'
+/// @date 25-Jan-2017
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef __mqtt_delivery_response_options_h
+#define __mqtt_delivery_response_options_h
+
+extern "C" {
+	#include "MQTTAsync.h"
+}
+
+#include "mqtt/delivery_token.h"
+
+namespace mqtt {
+
+/////////////////////////////////////////////////////////////////////////////
+//							delivery_response_options
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * The response options for asynchronous calls targeted at delivery.
+ * Each of these objects is tied to a specific delivery_token.
+ */
+class delivery_response_options
+{
+	/** The underlying C structure */
+	MQTTAsync_responseOptions opts_;
+
+	/** The delivery token to which we are connected */
+	delivery_token::weak_ptr_t dtok_;
+
+	/** The client has special access */
+	friend class async_client;
+	friend class delivery_response_options_test;
+
+public:
+	/**
+	 * Create an empty delivery response object.
+	 */
+	delivery_response_options();
+	/**
+	 * Creates a response object tied to the specific delivery token.
+	 * @param dtok A delivery token to be used as the context.
+	 */
+	delivery_response_options(const delivery_token_ptr& dtok);
+	/**
+	 * Sets the callback context to a delivery token.
+	 * @param dtok The delivery token to be used as the callback context.
+	 */
+	void set_token(const delivery_token_ptr& dtok) {
+		dtok_ = dtok;
+		opts_.context = dtok.get();
+	}
+};
+
+/////////////////////////////////////////////////////////////////////////////
+// end namespace 'mqtt'
+}
+
+#endif		// __mqtt_delivery_response_options_h

--- a/src/mqtt/response_options.h
+++ b/src/mqtt/response_options.h
@@ -12,7 +12,6 @@ extern "C" {
 }
 
 #include "mqtt/token.h"
-#include "mqtt/delivery_token.h"
 
 namespace mqtt {
 
@@ -57,46 +56,6 @@ public:
 	void set_token(const token_ptr& tok) {
 		tok_ = tok;
 		opts_.context = tok.get();
-	}
-};
-
-/////////////////////////////////////////////////////////////////////////////
-//							delivery_response_options
-/////////////////////////////////////////////////////////////////////////////
-
-/**
- * The response options for asynchronous calls targeted at delivery.
- * Each of these objects is tied to a specific delivery_token.
- */
-class delivery_response_options
-{
-	/** The underlying C structure */
-	MQTTAsync_responseOptions opts_;
-
-	/** The delivery token to which we are connected */
-	delivery_token::weak_ptr_t dtok_;
-
-	/** The client has special access */
-	friend class async_client;
-	friend class delivery_response_options_test;
-
-public:
-	/**
-	 * Create an empty delivery response object.
-	 */
-	delivery_response_options();
-	/**
-	 * Creates a response object tied to the specific delivery token.
-	 * @param dtok A delivery token to be used as the context.
-	 */
-	delivery_response_options(const delivery_token_ptr& dtok);
-	/**
-	 * Sets the callback context to a delivery token.
-	 * @param dtok The delivery token to be used as the callback context.
-	 */
-	void set_token(const delivery_token_ptr& dtok) {
-		dtok_ = dtok;
-		opts_.context = dtok.get();
 	}
 };
 

--- a/src/response_options.cpp
+++ b/src/response_options.cpp
@@ -20,21 +20,5 @@ response_options::response_options(const token_ptr& tok)
 }
 
 /////////////////////////////////////////////////////////////////////////////
-
-delivery_response_options::delivery_response_options()
-		: opts_(MQTTAsync_responseOptions_initializer)
-{
-	opts_.onSuccess = &delivery_token::on_success;
-	opts_.onFailure = &delivery_token::on_failure;
-}
-
-delivery_response_options::delivery_response_options(const delivery_token_ptr& tok)
-		: delivery_response_options()
-{
-	set_token(tok);
-}
-
-/////////////////////////////////////////////////////////////////////////////
 // end namespace 'mqtt'
 }
-

--- a/test/unit/delivery_response_options_test.h
+++ b/test/unit/delivery_response_options_test.h
@@ -23,7 +23,7 @@
 #include <cppunit/ui/text/TestRunner.h>
 #include <cppunit/extensions/HelperMacros.h>
 
-#include "mqtt/response_options.h"
+#include "mqtt/delivery_response_options.h"
 
 #include "dummy_async_client.h"
 


### PR DESCRIPTION
Synchronize the `delivery_token`'s (saved as `context `pointer) message ID with the message ID from the
`delivery_response_options `class. Because the `delivery_response_options`'s message ID (`MQTTAsync_responseOptions::token`) is updated by the Paho MQTT C right after the message is sent. At function `MQTTAsync_send()`. Whereas the `delivery_token`'s message ID is updated only after the response arrives. At either static methods `token::on_success()` or `token::on_failure()`. For example:

```
  idelivery_token_ptr async_client::publish(const std::string& topic, const_message_ptr msg)
  {
    idelivery_token_ptr tok = std::make_shared<delivery_token>(*this, topic, msg);
    ...
    delivery_response_options opts { dynamic_cast<delivery_token*>(tok.get()) };

    // NOTE 1: both tok and opts have zeroed message IDs

    int rc = MQTTAsync_sendMessage(cli_,
                                   const_cast<char*>(topic.c_str()),
                                   &(msg->get_c_struct()), &opts.get_c_struct());

    // NOTE 2: opts has a non-zero message ID, but tok still have a
    //         zeroed message ID. It will have its message ID set only
    //         when the static method token::on_success() is called
    ...

    return tok;
}
```

This solves a bug where ALL `delivery_token`s available from `async_client::get_pending_delivery_token()` have message ID equal to zero. Once they didn't have their message IDs updated yet.