### PR TITLE
Fix Doxygen documentation

### DIFF
--- a/src/mqtt/async_client.h
+++ b/src/mqtt/async_client.h
@@ -139,7 +139,7 @@ public:
 	/**
 	 * Create an async_client that can be used to communicate with an MQTT
 	 * server.
-	 * This allows the caller to specify a user-defined persistance object,
+	 * This allows the caller to specify a user-defined persistence object,
 	 * or use no persistence.
 	 * @param serverURI the address of the server to connect to, specified
 	 *  				as a URI.
@@ -178,6 +178,8 @@ public:
 	 *  			  defaults.
 	 * @param userContext optional object used to pass context to the
 	 *  				  callback. Use @em nullptr if not required.
+	 * @param cb callback listener that will be notified when the connect
+	 *  			   completes.
 	 * @return token used to track and wait for the connect to complete. The
 	 *  	   token will be passed to any callback that has been set.
 	 * @throw exception for non security related problems
@@ -189,7 +191,7 @@ public:
 	 *
 	 * @param userContext optional object used to pass context to the
 	 *  				  callback. Use @em nullptr if not required.
-	 * @param callback listener that will be notified when the connect
+	 * @param cb callback listener that will be notified when the connect
 	 *  			   completes.
 	 * @return token used to track and wait for the connect to complete. The
 	 *  	   token will be passed to any callback that has been set.
@@ -226,7 +228,7 @@ public:
 	 *  					 quiesce.
 	 * @param userContext optional object used to pass context to the
 	 *  				  callback. Use @em nullptr if not required.
-	 * @param callback listener that will be notified when the disconnect
+	 * @param cb callback listener that will be notified when the disconnect
 	 *  			   completes.
 	 * @return itoken_ptr Token used to track and wait for disconnect to
 	 *  	   complete. The token will be passed to the callback methods if
@@ -239,7 +241,7 @@ public:
 	 * Disconnects from the server.
 	 * @param userContext optional object used to pass context to the
 	 *  				  callback. Use @em nullptr if not required.
-	 * @param callback listener that will be notified when the disconnect
+	 * @param cb callback listener that will be notified when the disconnect
 	 *  			   completes.
 	 * @return itoken_ptr Token used to track and wait for disconnect to
 	 *  	   complete. The token will be passed to the callback methods if
@@ -323,7 +325,7 @@ public:
 	 * @param msg the message to deliver to the server
 	 * @param userContext optional object used to pass context to the
 	 *  				  callback. Use @em nullptr if not required.
-	 * @param callback optional listener that will be notified when message
+	 * @param cb callback optional listener that will be notified when message
 	 *  			   delivery has completed to the requested quality of
 	 *  			   service
 	 * @return token used to track and wait for the publish to complete. The
@@ -334,7 +336,7 @@ public:
 	/**
 	 * Sets a callback listener to use for events that happen
 	 * asynchronously.
-	 * @param callback which will be invoked for certain asynchronous events
+	 * @param cb callback which will be invoked for certain asynchronous events
 	 */
 	virtual void set_callback(callback& cb);
 	/**

--- a/src/mqtt/client.h
+++ b/src/mqtt/client.h
@@ -79,7 +79,7 @@ public:
 		   const std::string& persistDir);
 	/**
 	 * Create a client that can be used to communicate with an MQTT server.
-	 * This allows the caller to specify a user-defined persistance object,
+	 * This allows the caller to specify a user-defined persistence object,
 	 * or use no persistence.
 	 * @param serverURI
 	 * @param clientId
@@ -153,9 +153,9 @@ public:
 	/**
 	 * Publishes a message to a topic on the server and return once it is
 	 * delivered.
-	 * @param topic
-	 * @param payload
-	 * @param n
+	 * @param top The topic to publish
+	 * @param payload The data to publish
+	 * @param n The size in bytes of the data
 	 * @param qos
 	 * @param retained
 	 */
@@ -176,7 +176,7 @@ public:
 	/**
 	 * Sets the callback listener to use for events that happen
 	 * asynchronously.
-	 * @param callback
+	 * @param cb The callback functions
 	 */
 	virtual void set_callback(callback& cb);
 	/**
@@ -192,27 +192,30 @@ public:
 	/**
 	 * Subscribes to a one or more topics, which may include wildcards using
 	 * a QoS of 1.
+	 * @param topicFilters A set of topics to subscribe
 	 */
 	virtual void subscribe(const topic_filter_collection& topicFilters);
 	/**
 	 * Subscribes to multiple topics, each of which may include wildcards.
-	 * @param string
+	 * @param topicFilters A collection of topics to subscribe
+	 * @param qos A collection of QoS for each topic
 	 */
 	virtual void subscribe(const topic_filter_collection& topicFilters,
 						   const qos_collection& qos);
 	/**
 	 * Subscribe to a topic, which may include wildcards.
-	 * @param topicFilter
-	 * @param qos
+	 * @param topicFilter A single topic to subscribe
+	 * @param qos The QoS of the subscription
 	 */
 	virtual void subscribe(const std::string& topicFilter, int qos);
 	/**
 	 * Requests the server unsubscribe the client from a topic.
-	 * @param topicFilter
+	 * @param topicFilter A single topic to unsubscribe.
 	 */
 	virtual void unsubscribe(const std::string& topicFilter);
 	/**
 	 * Requests the server unsubscribe the client from one or more topics.
+	 * @param topicFilters A collection of topics to unsubscribe.
 	 */
 	virtual void unsubscribe(const topic_filter_collection& topicFilters);
 };

--- a/src/mqtt/delivery_token.h
+++ b/src/mqtt/delivery_token.h
@@ -97,20 +97,21 @@ public:
 	/**
 	 * Creates a delivery token connected to a particular client. 
 	 * @param cli The asynchronous client object. 
-	 * @param topic The topic that the message is assocaited with. 
+	 * @param topic The topic that the message is associated with.
 	 */
 	delivery_token(iasync_client& cli, const std::string& topic) : token(cli, topic) {}
 	/**
 	 * Creates a delivery token connected to a particular client. 
 	 * @param cli The asynchronous client object. 
-	 * @param topic The topic that the message is assocaited with. 
+	 * @param topic The topic that the message is associated with.
+	 * @param msg The message data.
 	 */
 	delivery_token(iasync_client& cli, const std::string& topic, const_message_ptr msg) 
 			: token(cli, topic), msg_(msg) {}
 	/**
 	 * Creates a delivery token connected to a particular client. 
 	 * @param cli The asynchronous client object. 
-	 * @param topics The topics that the message is assocaited with. 
+	 * @param topics The topics that the message is associated with.
 	 */
 	delivery_token(iasync_client& cli, const std::vector<std::string>& topics)
 					: token(cli, topics) {}

--- a/src/mqtt/iaction_listener.h
+++ b/src/mqtt/iaction_listener.h
@@ -64,9 +64,8 @@ public:
 	/**
 	 * This method is invoked when an action fails.
 	 * @param asyncActionToken
-	 * @param exc
 	 */
-	virtual void on_failure(const itoken& asyncActionToken /*, java.lang.Throwable exc*/) =0;
+	virtual void on_failure(const itoken& asyncActionToken) =0;
 	/**
 	 * This method is invoked when an action has completed successfully.
 	 * @param asyncActionToken

--- a/src/mqtt/iasync_client.h
+++ b/src/mqtt/iasync_client.h
@@ -93,7 +93,8 @@ public:
 	 *  			  defaults.
 	 * @param userContext optional object used to pass context to the
 	 *  				  callback. Use @em nullptr if not required.
-	 *
+	 * @param cb callback listener that will be notified when the connect
+	 *  			   completes.
 	 * @return token used to track and wait for the connect to complete. The
 	 *  	   token will be passed to any callback that has been set.
 	 * @throw exception for non security related problems

--- a/src/mqtt/iclient_persistence.h
+++ b/src/mqtt/iclient_persistence.h
@@ -81,7 +81,7 @@ public:
 	 */
 	virtual ~iclient_persistence() {}
 	/**
-	 * Initialise the persistent store.
+	 * Initialize the persistent store.
 	 */
 	virtual void open(const std::string& clientId, const std::string& serverURI) =0;
 	/**

--- a/src/mqtt/ipersistable.h
+++ b/src/mqtt/ipersistable.h
@@ -66,7 +66,7 @@ namespace mqtt {
  *
  * @li
  * It could return the header and payload as a contiguous byte array with
- * the header bytes preceeding the payload. The contiguous byte array should
+ * the header bytes preceding the payload. The contiguous byte array should
  * be set as the header byte array, with the payload byte array being null.
  * For example, return a single byte array with offset 0 and length 40004.
  * This is useful when recovering from a file where the header and payload

--- a/src/mqtt/message.h
+++ b/src/mqtt/message.h
@@ -76,14 +76,14 @@ public:
 	 * Constructs a message with the specified array as a payload, and all
 	 * other values set to defaults.
 	 * @param payload the bytes to use as the message payload
-	 * @param n the number of bytes in the payload
+	 * @param len the number of bytes in the payload
 	 */
 	message(const void* payload, size_t len);
 	/**
 	 * Constructs a message with the specified array as a payload, and all
 	 * other values set to defaults.
 	 * @param payload the bytes to use as the message payload
-	 * @param n the number of bytes in the payload
+	 * @param len the number of bytes in the payload
 	 * @param qos The quality of service for the message.
 	 * @param retained Whether the message should be retained by the broker.
 	 */
@@ -210,7 +210,7 @@ using const_message_ptr = message::const_ptr_t;
  * Constructs a message with the specified array as a payload, and all
  * other values set to defaults.
  * @param payload the bytes to use as the message payload
- * @param n the number of bytes in the payload
+ * @param len the number of bytes in the payload
  */
 inline message_ptr make_message(const void* payload, size_t len) {
 	return std::make_shared<mqtt::message>(payload, len);
@@ -220,7 +220,7 @@ inline message_ptr make_message(const void* payload, size_t len) {
  * Constructs a message with the specified array as a payload, and all
  * other values set to defaults.
  * @param payload the bytes to use as the message payload
- * @param n the number of bytes in the payload
+ * @param len the number of bytes in the payload
  * @param qos The quality of service for the message.
  * @param retained Whether the message should be retained by the broker.
  */

--- a/src/mqtt/response_options.h
+++ b/src/mqtt/response_options.h
@@ -38,7 +38,7 @@ public:
 	response_options();
 	/**
 	 * Creates a response object with the specified callbacks. 
-	 * @param dtok A token to be used as the context.
+	 * @param tok A token to be used as the context.
 	 */
 	response_options(token* tok);
 
@@ -84,7 +84,7 @@ public:
 	delivery_response_options(delivery_token* dtok);
 	/**
 	 * Sets the callback context to a delivery token. 
-	 * @param tok The delivery token to be used as the callback context.
+	 * @param dtok The delivery token to be used as the callback context.
 	 */
 	void set_context(delivery_token* dtok) { 
 		opts_.context = dtok;

--- a/src/mqtt/token.h
+++ b/src/mqtt/token.h
@@ -211,17 +211,20 @@ public:
 	token(iasync_client& cli);
 	/**
 	 * Constructs a token object.
+	 * @param cli
 	 * @param tok
 	 */
 	token(iasync_client& cli, MQTTAsync_token tok);
 	/**
 	 * Constructs a token object.
 	 * @param cli
+	 * @param topic
 	 */
 	token(iasync_client& cli, const std::string& topic);
 	/**
 	 * Constructs a token object.
 	 * @param cli
+	 * @param topics
 	 */
 	token(iasync_client& cli, const std::vector<std::string>& topics);
 	/**

--- a/src/mqtt/topic.h
+++ b/src/mqtt/topic.h
@@ -86,13 +86,13 @@ public:
 	 *
 	 * @return delivery_token
 	 */
-	idelivery_token_ptr publish(const std::string& str, int qos, bool retained) {
-		return publish(str.data(), str.length(), qos, retained);
+	idelivery_token_ptr publish(const std::string& payload, int qos, bool retained) {
+		return publish(payload.data(), payload.length(), qos, retained);
 	}
 	/**
 	 * Publishes the specified message to this topic, but does not wait for
 	 * delivery of the message to complete.
-	 * @param message
+	 * @param msg
 	 * @return delivery_token
 	 */
 	idelivery_token_ptr publish(const_message_ptr msg);


### PR DESCRIPTION
Rename, remove and add a parameter to match documentation and signature.
Fix some typos and misspellings. Fix errors reported by doxygen 1.8.3.