### PR TITLE
Use a enum class for QoS type

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,7 @@ libpaho_mqttpp3_la_SOURCES += src/client.cpp
 libpaho_mqttpp3_la_SOURCES += src/disconnect_options.cpp
 libpaho_mqttpp3_la_SOURCES += src/iclient_persistence.cpp
 libpaho_mqttpp3_la_SOURCES += src/message.cpp
+libpaho_mqttpp3_la_SOURCES += src/qos.cpp
 libpaho_mqttpp3_la_SOURCES += src/response_options.cpp
 libpaho_mqttpp3_la_SOURCES += src/token.cpp
 libpaho_mqttpp3_la_SOURCES += src/topic.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,7 @@ set(COMMON_SRC
     disconnect_options.cpp
     iclient_persistence.cpp
     message.cpp
+    qos.cpp
     response_options.cpp
     token.cpp
     topic.cpp

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -24,7 +24,7 @@
 
 namespace mqtt {
 
-const int client::DFLT_QOS = 1;
+const QoS client::DFLT_QOS = QoS::QOS1;
 
 /////////////////////////////////////////////////////////////////////////////
 
@@ -70,10 +70,6 @@ void client::disconnect(long timeout)
 	cli_.disconnect(timeout)->wait_for_completion(timeout_);
 }
 
-//std::string client::generate_client_id()
-//{
-//}
-
 std::string client::get_client_id() const
 {
 	return cli_.get_client_id();
@@ -108,7 +104,7 @@ bool client::is_connected() const
 }
 
 void client::publish(const std::string& top, const void* payload, size_t n,
-					 int qos, bool retained)
+					 QoS qos, bool retained)
 {
 	cli_.publish(top, payload, n, qos, retained)->wait_for_completion(timeout_);
 }
@@ -156,7 +152,7 @@ void client::subscribe(const topic_filter_collection& topicFilters,
 	cli_.subscribe(topicFilters, qos)->wait_for_completion(timeout_);
 }
 
-void client::subscribe(const std::string& topicFilter, int qos)
+void client::subscribe(const std::string& topicFilter, QoS qos)
 {
 	cli_.subscribe(topicFilter, qos)->wait_for_completion(timeout_);
 }

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -35,7 +35,7 @@ message::message(const void* payload, size_t len)
 	set_payload(payload, len);
 }
 
-message::message(const void* payload, size_t len, int qos, bool retained)
+message::message(const void* payload, size_t len, QoS qos, bool retained)
 						: msg_(MQTTAsync_message_initializer)
 {
 	set_payload(payload, len);
@@ -49,7 +49,7 @@ message::message(const std::string& payload)
 	set_payload(payload);
 }
 
-message::message(const std::string& payload, int qos, bool retained)
+message::message(const std::string& payload, QoS qos, bool retained)
 						: msg_(MQTTAsync_message_initializer)
 {
 	set_payload(payload);
@@ -123,6 +123,12 @@ void message::set_payload(const std::string& payload)
 	payload_ = payload;
 	msg_.payload = const_cast<char*>(payload_.data());
 	msg_.payloadlen = payload_.length();
+}
+
+void message::set_qos(QoS qos)
+{
+	validate_qos(qos);
+	msg_.qos = static_cast<int>(qos);
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/mqtt/async_client.h
+++ b/src/mqtt/async_client.h
@@ -28,6 +28,7 @@ extern "C" {
 	#include "MQTTAsync.h"
 }
 
+#include "mqtt/qos.h"
 #include "mqtt/token.h"
 #include "mqtt/delivery_token.h"
 #include "mqtt/iclient_persistence.h"
@@ -289,7 +290,7 @@ public:
 	 *  	   token will be passed to callback methods if set.
 	 */
 	idelivery_token_ptr publish(const std::string& topic, const void* payload,
-										size_t n, int qos, bool retained) override;
+										size_t n, QoS qos, bool retained) override;
 	/**
 	 * Publishes a message to a topic on the server
 	 * @param topic The topic to deliver the message to
@@ -307,7 +308,7 @@ public:
 	 */
 	idelivery_token_ptr publish(const std::string& topic,
 										const void* payload, size_t n,
-										int qos, bool retained, void* userContext,
+										QoS qos, bool retained, void* userContext,
 										iaction_listener& cb) override;
 	/**
 	 * Publishes a message to a topic on the server Takes an Message
@@ -378,7 +379,7 @@ public:
 	 * @return token used to track and wait for the subscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	itoken_ptr subscribe(const std::string& topicFilter, int qos) override;
+	itoken_ptr subscribe(const std::string& topicFilter, QoS qos) override;
 	/**
 	 * Subscribe to a topic, which may include wildcards.
 	 * @param topicFilter the topic to subscribe to, which can include
@@ -394,7 +395,7 @@ public:
 	 * @return token used to track and wait for the subscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	itoken_ptr subscribe(const std::string& topicFilter, int qos,
+	itoken_ptr subscribe(const std::string& topicFilter, QoS qos,
 								 void* userContext, iaction_listener& cb) override;
 	/**
 	 * Requests the server unsubscribe the client from a topic.

--- a/src/mqtt/client.h
+++ b/src/mqtt/client.h
@@ -25,6 +25,7 @@
 #define __mqtt_client_h
 
 #include "async_client.h"
+#include "mqtt/qos.h"
 
 #include <string>
 #include <memory>
@@ -40,7 +41,7 @@ namespace mqtt {
 class client
 {
 	/** The default quality of service */
-	static const int DFLT_QOS;
+	static const QoS DFLT_QOS;
 	/** The actual client */
 	async_client cli_;
 	/**
@@ -160,7 +161,7 @@ public:
 	 * @param retained
 	 */
 	virtual void publish(const std::string& top, const void* payload, size_t n,
-						 int qos, bool retained);
+						 QoS qos, bool retained);
 	/**
 	 * Publishes a message to a topic on the server.
 	 * @param top The topic to publish on
@@ -207,7 +208,7 @@ public:
 	 * @param topicFilter A single topic to subscribe
 	 * @param qos The QoS of the subscription
 	 */
-	virtual void subscribe(const std::string& topicFilter, int qos);
+	virtual void subscribe(const std::string& topicFilter, QoS qos);
 	/**
 	 * Requests the server unsubscribe the client from a topic.
 	 * @param topicFilter A single topic to unsubscribe.

--- a/src/mqtt/connect_options.h
+++ b/src/mqtt/connect_options.h
@@ -28,6 +28,7 @@ extern "C" {
 	#include "MQTTAsync.h"
 }
 
+#include "mqtt/qos.h"
 #include "mqtt/message.h"
 #include "mqtt/topic.h"
 #include "mqtt/will_options.h"

--- a/src/mqtt/iasync_client.h
+++ b/src/mqtt/iasync_client.h
@@ -62,7 +62,7 @@ public:
 	/** Type for a collection of filters */
 	using topic_filter_collection = std::vector<std::string>;
 	/** Type for a collection of QOS values */
-	using qos_collection = std::vector<int>;
+	using qos_collection = std::vector<QoS>;
 
 	/**
 	 * Virtual destructor
@@ -186,7 +186,7 @@ public:
 	 *  	   token will be passed to callback methods if set.
 	 */
 	virtual idelivery_token_ptr publish(const std::string& topic, const void* payload,
-										size_t n, int qos, bool retained) =0;
+										size_t n, QoS qos, bool retained) =0;
 	/**
 	 * Publishes a message to a topic on the server
 	 * @param topic The topic to deliver the message to
@@ -203,7 +203,7 @@ public:
 	 */
 	virtual idelivery_token_ptr publish(const std::string& topic,
 										const void* payload, size_t n,
-										int qos, bool retained, void* userContext,
+										QoS qos, bool retained, void* userContext,
 										iaction_listener& cb) =0;
 	/**
 	 * Publishes a message to a topic on the server Takes an Message
@@ -282,7 +282,7 @@ public:
 	 * @return token used to track and wait for the subscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr subscribe(const std::string& topicFilter, int qos) =0;
+	virtual itoken_ptr subscribe(const std::string& topicFilter, QoS qos) =0;
 	/**
 	 * Subscribe to a topic, which may include wildcards.
 	 * @param topicFilter the topic to subscribe to, which can include
@@ -299,7 +299,7 @@ public:
 	 * @return token used to track and wait for the subscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr subscribe(const std::string& topicFilter, int qos,
+	virtual itoken_ptr subscribe(const std::string& topicFilter, QoS qos,
 								 void* userContext, iaction_listener& callback) =0;
 	/**
 	 * Requests the server unsubscribe the client from a topic.

--- a/src/mqtt/message.h
+++ b/src/mqtt/message.h
@@ -32,6 +32,8 @@ extern "C" {
 #include <memory>
 #include <stdexcept>
 
+#include "mqtt/qos.h"
+
 namespace mqtt {
 
 /////////////////////////////////////////////////////////////////////////////
@@ -87,7 +89,7 @@ public:
 	 * @param qos The quality of service for the message.
 	 * @param retained Whether the message should be retained by the broker.
 	 */
-	message(const void* payload, size_t len, int qos, bool retained);
+	message(const void* payload, size_t len, QoS qos, bool retained);
 	/**
 	 * Constructs a message with the specified string as a payload, and
 	 * all other values set to defaults.
@@ -100,7 +102,7 @@ public:
 	 * @param qos The quality of service for the message.
 	 * @param retained Whether the message should be retained by the broker.
 	 */
-	message(const std::string& payload, int qos, bool retained);
+	message(const std::string& payload, QoS qos, bool retained);
 	/**
 	 * Constructs a message as a copy of the message structure.
 	 * @param msg A "C" MQTTAsync_message structure.
@@ -144,7 +146,7 @@ public:
 	 * Returns the quality of service for this message.
 	 * @return The quality of service for this message.
 	 */
-	int get_qos() const { return msg_.qos; }
+	QoS get_qos() const { return static_cast<QoS>(msg_.qos); }
 	/**
 	 * Returns whether or not this message might be a duplicate of one which
 	 * has already been received.
@@ -174,10 +176,7 @@ public:
 	 * Sets the quality of service for this message.
 	 * @param qos The integer Quality of Service for the message
 	 */
-	void set_qos(int qos) {
-		validate_qos(qos);
-		msg_.qos = qos;
-	}
+	void set_qos(QoS qos);
 	/**
 	 * Whether or not the publish message should be retained by the broker.
 	 * @param retained @em true if the message should be retained by the
@@ -189,15 +188,6 @@ public:
 	 * @return std::string
 	 */
 	std::string to_str() const { return get_payload(); }
-	/**
-	 * Determines if the QOS value is a valid one.
-	 * @param qos The QOS value.
-	 * @throw std::invalid_argument If the qos value is invalid.
-	 */
-	static void validate_qos(int qos) {
-		if (qos < 0 || qos > 2)
-			throw std::invalid_argument("QOS invalid");
-	}
 };
 
 /** Smart/shared pointer to a message */
@@ -225,7 +215,7 @@ inline message_ptr make_message(const void* payload, size_t len) {
  * @param retained Whether the message should be retained by the broker.
  */
 inline message_ptr make_message(const void* payload, size_t len,
-								int qos, bool retained) {
+								QoS qos, bool retained) {
 	return std::make_shared<mqtt::message>(payload, len, qos, retained);
 }
 
@@ -245,7 +235,7 @@ inline message_ptr make_message(const std::string& payload) {
  * @param qos The quality of service for the message.
  * @param retained Whether the message should be retained by the broker.
  */
-inline message_ptr make_message(const std::string& payload, int qos, bool retained) {
+inline message_ptr make_message(const std::string& payload, QoS qos, bool retained) {
 	return std::make_shared<mqtt::message>(payload, qos, retained);
 }
 

--- a/src/mqtt/qos.h
+++ b/src/mqtt/qos.h
@@ -1,0 +1,93 @@
+/////////////////////////////////////////////////////////////////////////////
+/// @file qos.h
+/// Declaration of MQTT QoS class
+/// @date Jul 8, 2016
+/// @author Guilherme Maciel Ferreira
+/////////////////////////////////////////////////////////////////////////////
+
+/*******************************************************************************
+ * Copyright (c) 2016 Guilherme M. Ferreira <guilherme.maciel.ferreira@gmail.com>
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Guilherme M. Ferreira - initial implementation and documentation
+ ******************************************************************************/
+
+#ifndef __mqtt_qos_h
+#define __mqtt_qos_h
+
+#include <ostream>
+
+namespace mqtt {
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Quality of Service values.
+ *
+ * One of the following delivery values:
+ *
+ * - "At most once", where messages are delivered according to the best efforts
+ *   of the underlying TCP/IP network. Message loss or duplication can occur.
+ *   This level can be used in systems where it does not matter if an individual
+ *   message is lost as the next one will be published soon after.
+ *
+ * - "At least once", where messages are assured to arrive at least once, but
+ *   duplicates may occur.
+ *
+ * - "Exactly once", where message are assured to arrive exactly once. This
+ *   level must be used in systems where duplicate or lost messages can lead
+ *   to incorrect results.
+ *
+ */
+enum class QoS : int
+{
+	QOS0 = 0,	// Fire and Forget
+	QOS1 = 1,	// Acknowledged delivery
+	QOS2 = 2,	// Assured delivery, exactly once
+};
+
+/**
+ * Determines if the QOS value is a valid one.
+ * @param qos The QOS value.
+ * @throw std::invalid_argument If the qos value is invalid.
+ */
+void validate_qos(QoS qos);
+
+/**
+ * Determines if the QOS value is a valid one.
+ * @param qos The QOS value.
+ * @throw std::invalid_argument If the qos value is invalid.
+ */
+void validate_qos(int qos);
+
+/**
+ * Insertion operator for mqtt::QoS
+ * @param os Output stream
+ * @param qos The QoS to print
+ * @return The output stream passed as argument
+ */
+std::ostream& operator<<(std::ostream& os, QoS qos);
+
+/**
+ * Comparison operator
+ * @param qosa The first QoS
+ * @param qosb The second QoS
+ * @return true if both QoSes have the same numeric value
+ */
+bool operator==(QoS qosa, QoS qosb);
+
+/////////////////////////////////////////////////////////////////////////////
+// end namespace mqtt
+}
+
+#endif		// __mqtt_qos_h
+

--- a/src/mqtt/topic.h
+++ b/src/mqtt/topic.h
@@ -30,6 +30,7 @@ extern "C" {
 
 #include "mqtt/delivery_token.h"
 #include "mqtt/message.h"
+#include "mqtt/qos.h"
 #include <string>
 #include <vector>
 #include <memory>
@@ -77,7 +78,7 @@ public:
 	 *
 	 * @return delivery_token
 	 */
-	idelivery_token_ptr publish(const void* payload, size_t n, int qos, bool retained);
+	idelivery_token_ptr publish(const void* payload, size_t n, QoS qos, bool retained);
 	/**
 	 * Publishes a message on the topic.
 	 * @param payload
@@ -86,7 +87,7 @@ public:
 	 *
 	 * @return delivery_token
 	 */
-	idelivery_token_ptr publish(const std::string& payload, int qos, bool retained);
+	idelivery_token_ptr publish(const std::string& payload, QoS qos, bool retained);
 	/**
 	 * Publishes the specified message to this topic, but does not wait for
 	 * delivery of the message to complete.

--- a/src/mqtt/will_options.h
+++ b/src/mqtt/will_options.h
@@ -82,7 +82,7 @@ public:
 		const std::string& top,
 		const void *payload,
 		size_t payload_len,
-		int qos,
+		QoS qos,
 		bool retained
 	);
 	/**
@@ -97,7 +97,7 @@ public:
 		const topic& top,
 		const void *payload,
 		size_t payload_len,
-		int qos,
+		QoS qos,
 		bool retained
 	);
 	/**
@@ -111,7 +111,7 @@ public:
 	will_options(
 		const std::string& top,
 		const std::string& payload,
-		int qos,
+		QoS qos,
 		bool retained
 	);
 	/**
@@ -157,7 +157,9 @@ public:
 	 * Gets the QoS value for the LWT message.
 	 * @return The QoS value for the LWT message.
 	 */
-	int get_qos() const { return opts_.qos; }
+	QoS get_qos() const {
+		return static_cast<QoS>(opts_.qos);
+	}
 	/**
 	 * Gets the 'retained' flag for the LWT message.
 	 * @return The 'retained' flag for the LWT message.
@@ -170,7 +172,7 @@ public:
 	 * @return A copy of the LWT message.
 	 */
 	const_message_ptr get_message() const {
-		return make_message(payload_, opts_.qos, opts_.retained);
+		return make_message(payload_, static_cast<QoS>(opts_.qos), opts_.retained);
 	}
 	/**
 	 * Sets the LWT message topic name.
@@ -186,7 +188,7 @@ public:
 	 * Sets the QoS value.
 	 * @param qos The LWT message QoS
 	 */
-	void set_qos(const int qos) { opts_.qos = qos; }
+	void set_qos(const QoS qos);
 	/**
 	 * Sets the retained flag.
 	 * @param retained Tell the broker to keep the LWT message after send to

--- a/src/qos.cpp
+++ b/src/qos.cpp
@@ -1,7 +1,5 @@
-// topic.cpp
-
 /*******************************************************************************
- * Copyright (c) 2013-2016 Frank Pagliughi <fpagliughi@mindspring.com>
+ * Copyright (c) 2016 Guilherme M. Ferreira <guilherme.maciel.ferreira@gmail.com>
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,36 +11,37 @@
  *   http://www.eclipse.org/org/documents/edl-v10.php.
  *
  * Contributors:
- *    Frank Pagliughi - initial implementation and documentation
+ *    Guilherme M. Ferreira - initial implementation and documentation
  *******************************************************************************/
 
+#include "mqtt/qos.h"
 
-#include "mqtt/topic.h"
-#include "mqtt/async_client.h"
+#include "mqtt/exception.h"
 
 namespace mqtt {
 
 /////////////////////////////////////////////////////////////////////////////
 
-idelivery_token_ptr topic::publish(const void* payload, size_t n,
-								   QoS qos, bool retained)
-{
-	return cli_->publish(name_, payload, n, qos, retained);
+void validate_qos(QoS qos) {
+	validate_qos(static_cast<int>(qos));
 }
 
-idelivery_token_ptr topic::publish(const std::string& payload, QoS qos, bool retained)
-{
-	return publish(payload.data(), payload.length(), qos, retained);
+void validate_qos(int qos) {
+	if ((qos < 0) || (2 < qos))
+		throw mqtt::exception(MQTTASYNC_BAD_QOS);
 }
 
-idelivery_token_ptr topic::publish(const_message_ptr msg)
-{
-	return cli_->publish(name_, msg);
+std::ostream& operator<<(std::ostream& os, QoS qos) {
+	int iqos = static_cast<int>(qos);
+	os << iqos;
+	return os;
+}
+
+bool operator==(QoS qosa, QoS qosb) {
+	return (static_cast<int>(qosa) == static_cast<int>(qosb));
 }
 
 /////////////////////////////////////////////////////////////////////////////
-// end namespace mqtt
-}
 
-
+} // end namespace mqtt
 

--- a/src/samples/async_publish.cpp
+++ b/src/samples/async_publish.cpp
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <cstring>
 #include "mqtt/async_client.h"
+#include "mqtt/qos.h"
 
 using namespace std;
 
@@ -37,7 +38,7 @@ const char* PAYLOAD4 = "Someone is always listening.";
 
 const char* LWT_PAYLOAD = "Last will and testament.";
 
-const int  QOS = 1;
+const mqtt::QoS QOS = mqtt::QoS::QOS1;
 const long TIMEOUT = 10000L;
 
 inline void sleep(int ms) {
@@ -124,7 +125,7 @@ int main(int argc, char* argv[])
 	client.set_callback(cb);
 
 	mqtt::connect_options conopts;
-	mqtt::message willmsg(LWT_PAYLOAD, 1, true);
+	mqtt::message willmsg(LWT_PAYLOAD, mqtt::QoS::QOS1, true);
 	mqtt::will_options will(TOPIC, willmsg);
 	conopts.set_will(will);
 

--- a/src/samples/async_subscribe.cpp
+++ b/src/samples/async_subscribe.cpp
@@ -27,7 +27,7 @@ const std::string ADDRESS("tcp://localhost:1883");
 const std::string CLIENTID("AsyncSubcriber");
 const std::string TOPIC("hello");
 
-const int  QOS = 1;
+const mqtt::QoS QOS = mqtt::QoS::QOS1;
 const long TIMEOUT = 10000L;
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/samples/sync_publish.cpp
+++ b/src/samples/sync_publish.cpp
@@ -36,7 +36,7 @@ const std::string PAYLOAD1("Hello World!");
 const char* PAYLOAD2 = "Hi there!";
 const char* PAYLOAD3 = "Is anyone listening?";
 
-const int QOS = 1;
+const mqtt::QoS QOS = mqtt::QoS::QOS1;
 const int TIMEOUT = 10000;
 
 /////////////////////////////////////////////////////////////////////////////
@@ -172,7 +172,7 @@ int main(int argc, char* argv[])
 		// Now try with itemized publish.
 
 		std::cout << "\nSending next message..." << std::endl;
-		client.publish(TOPIC, PAYLOAD2, strlen(PAYLOAD2)+1, 0, false);
+		client.publish(TOPIC, PAYLOAD2, strlen(PAYLOAD2)+1, mqtt::QoS::QOS0, false);
 		std::cout << "...OK" << std::endl;
 
 		// Now try with a listener, no token, and non-heap message

--- a/src/will_options.cpp
+++ b/src/will_options.cpp
@@ -33,35 +33,34 @@ will_options::will_options()
 will_options::will_options(const std::string& top,
 						   const void *payload,
 						   size_t payload_len,
-						   int qos,
+						   QoS qos,
 						   bool retained)
 		: opts_(MQTTAsync_willOptions_initializer), topic_(top),
 			payload_(static_cast<const char *>(payload), payload_len)
 {
 	opts_.topicName = topic_.c_str();
 	opts_.message = payload_.c_str();
-	opts_.qos = qos;
+	opts_.qos = static_cast<int>(qos);
 	opts_.retained = retained;
 }
 
 will_options::will_options(const topic& top,
 						   const void *payload,
 						   size_t payload_len,
-						   int qos, bool retained)
+						   QoS qos, bool retained)
 		: will_options(top.get_name(), payload, payload_len, qos, retained)
 {
 }
 
-
 will_options::will_options(const std::string& top,
 						   const std::string& payload,
-						   int qos, bool retained)
+						   QoS qos, bool retained)
 		: opts_(MQTTAsync_willOptions_initializer),
 			topic_(top), payload_(payload)
 {
 	opts_.topicName = topic_.c_str();
 	opts_.message = payload_.c_str();
-	opts_.qos = qos;
+	opts_.qos = static_cast<int>(qos);
 	opts_.retained = retained;
 }
 
@@ -129,6 +128,11 @@ void will_options::set_payload(const std::string& msg)
 {
 	payload_ = msg;
 	opts_.message = payload_.c_str();
+}
+
+void will_options::set_qos(const QoS qos) {
+	validate_qos(qos);
+	opts_.qos = static_cast<int>(qos);
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/test/unit/dummy_async_client.h
+++ b/test/unit/dummy_async_client.h
@@ -25,6 +25,7 @@
 #include "mqtt/iasync_client.h"
 #include "mqtt/token.h"
 #include "mqtt/connect_options.h"
+#include "mqtt/qos.h"
 
 namespace mqtt {
 namespace test {
@@ -89,14 +90,14 @@ public:
 	};
 
 	mqtt::idelivery_token_ptr publish(const std::string& topic, const void* payload,
-			size_t n, int qos, bool retained) override {
+			size_t n, mqtt::QoS qos, bool retained) override {
 		auto msg = mqtt::make_message(payload, n, qos, retained);
 		return publish(topic, msg);
 	};
 
 	mqtt::idelivery_token_ptr publish(const std::string& topic,
 			const void* payload, size_t n,
-			int qos, bool retained, void* userContext,
+			mqtt::QoS qos, bool retained, void* userContext,
 			mqtt::iaction_listener& cb) override {
 		return mqtt::idelivery_token_ptr{};
 	}
@@ -123,11 +124,11 @@ public:
 		return mqtt::itoken_ptr{};
 	}
 
-	mqtt::itoken_ptr subscribe(const std::string& topicFilter, int qos) override {
+	mqtt::itoken_ptr subscribe(const std::string& topicFilter, mqtt::QoS qos) override {
 		return mqtt::itoken_ptr{};
 	}
 
-	mqtt::itoken_ptr subscribe(const std::string& topicFilter, int qos,
+	mqtt::itoken_ptr subscribe(const std::string& topicFilter, mqtt::QoS qos,
 			void* userContext, mqtt::iaction_listener& callback) override {
 		return mqtt::itoken_ptr{};
 	}

--- a/test/unit/message_test.h
+++ b/test/unit/message_test.h
@@ -44,17 +44,16 @@ class message_test : public CppUnit::TestFixture
 	CPPUNIT_TEST( test_move_constructor );
 	CPPUNIT_TEST( test_copy_assignment );
 	CPPUNIT_TEST( test_move_assignment );
-	CPPUNIT_TEST( test_validate_qos );
 
 	CPPUNIT_TEST_SUITE_END();
 
 	const std::string EMPTY_STR;
-	const int DFLT_QOS = 0;
+	const mqtt::QoS DFLT_QOS = mqtt::QoS::QOS0;
 
 	const char* BUF = "Hello there";
 	const size_t N = std::strlen(BUF);
 	const std::string PAYLOAD = std::string(BUF);
-	const int QOS = 1;
+	const mqtt::QoS QOS = mqtt::QoS::QOS1;
 
 	mqtt::message orgMsg;
 
@@ -129,7 +128,7 @@ public:
 		MQTTAsync_message c_msg = MQTTAsync_message_initializer;
 		c_msg.payload = const_cast<char*>(BUF);
 		c_msg.payloadlen = N;
-		c_msg.qos = QOS;
+		c_msg.qos = static_cast<int>(QOS);
 		c_msg.retained = 1;
 		c_msg.dup = 1;
 		mqtt::message msg(c_msg);
@@ -232,52 +231,6 @@ public:
 		CPPUNIT_ASSERT_EQUAL(PAYLOAD, msg.get_payload());
 		CPPUNIT_ASSERT_EQUAL(QOS, msg.get_qos());
 		CPPUNIT_ASSERT(msg.is_retained());
-	}
-
-// ----------------------------------------------------------------------
-// Test the validate_qos()
-// ----------------------------------------------------------------------
-
-	void test_validate_qos() {
-		bool pass_lower = false;
-		try {
-			mqtt::message::validate_qos(-1);
-		} catch (std::invalid_argument& ex) {
-			pass_lower = true;
-		}
-		CPPUNIT_ASSERT(pass_lower);
-
-		bool pass_0 = true;
-		try {
-			mqtt::message::validate_qos(0);
-		} catch (std::invalid_argument& ex) {
-			pass_0 = false;
-		}
-		CPPUNIT_ASSERT(pass_0);
-
-		bool pass_1 = true;
-		try {
-			mqtt::message::validate_qos(1);
-		} catch (std::invalid_argument& ex) {
-			pass_1 = false;
-		}
-		CPPUNIT_ASSERT(pass_1);
-
-		bool pass_2 = true;
-		try {
-			mqtt::message::validate_qos(2);
-		} catch (std::invalid_argument& ex) {
-			pass_2 = false;
-		}
-		CPPUNIT_ASSERT(pass_2);
-
-		bool pass_higher = false;
-		try {
-			mqtt::message::validate_qos(3);
-		} catch (std::invalid_argument& ex) {
-			pass_higher = true;
-		}
-		CPPUNIT_ASSERT(pass_higher);
 	}
 
 };

--- a/test/unit/qos_test.h
+++ b/test/unit/qos_test.h
@@ -1,0 +1,98 @@
+// qos_test.h
+// Unit tests for the qos class in the Paho MQTT C++ library.
+
+/*******************************************************************************
+ * Copyright (c) 2016 Guilherme M. Ferreira <guilherme.maciel.ferreira@gmail.com>
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Guilherme M. Ferreira - initial implementation and documentation
+ *******************************************************************************/
+
+#ifndef __mqtt_qos_test_h
+#define __mqtt_qos_test_h
+
+#include <cppunit/ui/text/TestRunner.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+#include <cstring>
+
+#include "mqtt/qos.h"
+
+namespace mqtt {
+
+/////////////////////////////////////////////////////////////////////////////
+
+class qos_test : public CppUnit::TestFixture
+{
+	CPPUNIT_TEST_SUITE( qos_test );
+
+	CPPUNIT_TEST( test_validate_qos );
+
+	CPPUNIT_TEST_SUITE_END();
+
+public:
+	void setUp() {}
+	void tearDown() {}
+
+// ----------------------------------------------------------------------
+// Test the validate_qos()
+// ----------------------------------------------------------------------
+
+	void test_validate_qos() {
+		bool pass_lower = false;
+		try {
+			mqtt::validate_qos(-1);
+		} catch (std::invalid_argument& ex) {
+			pass_lower = true;
+		}
+		CPPUNIT_ASSERT(pass_lower);
+
+		bool pass_0 = true;
+		try {
+			mqtt::validate_qos(0);
+		} catch (std::invalid_argument& ex) {
+			pass_0 = false;
+		}
+		CPPUNIT_ASSERT(pass_0);
+
+		bool pass_1 = true;
+		try {
+			mqtt::validate_qos(1);
+		} catch (std::invalid_argument& ex) {
+			pass_1 = false;
+		}
+		CPPUNIT_ASSERT(pass_1);
+
+		bool pass_2 = true;
+		try {
+			mqtt::validate_qos(2);
+		} catch (std::invalid_argument& ex) {
+			pass_2 = false;
+		}
+		CPPUNIT_ASSERT(pass_2);
+
+		bool pass_higher = false;
+		try {
+			mqtt::validate_qos(3);
+		} catch (std::invalid_argument& ex) {
+			pass_higher = true;
+		}
+		CPPUNIT_ASSERT(pass_higher);
+	}
+
+};
+
+/////////////////////////////////////////////////////////////////////////////
+// end namespace mqtt
+}
+
+#endif		//  __mqtt_qos_test_h

--- a/test/unit/topic_test.h
+++ b/test/unit/topic_test.h
@@ -81,7 +81,7 @@ public:
 
 		CPPUNIT_ASSERT_EQUAL(msg_in->get_payload(), msg_out->get_payload());
 		CPPUNIT_ASSERT_EQUAL(msg_in->get_qos(), msg_out->get_qos());
-		CPPUNIT_ASSERT_EQUAL(0, msg_out->get_qos());
+		CPPUNIT_ASSERT_EQUAL(mqtt::QoS::QOS0, msg_out->get_qos());
 	}
 
 // ----------------------------------------------------------------------
@@ -92,7 +92,7 @@ public:
 		mqtt::topic topic{ TOPIC_NAME, cli };
 
 		std::string payload { "message" };
-		int qos { 1 };
+		mqtt::QoS qos { mqtt::QoS::QOS1 };
 
 		mqtt::idelivery_token_ptr token { topic.publish(payload, qos, false) };
 		CPPUNIT_ASSERT(token);
@@ -113,7 +113,7 @@ public:
 
 		std::string payload { "message" };
 		std::size_t payload_size { payload.size() };
-		int qos { 2 };
+		mqtt::QoS qos { mqtt::QoS::QOS2 };
 
 		mqtt::idelivery_token_ptr token = topic.publish(payload.c_str(), payload_size, qos, false);
 		CPPUNIT_ASSERT(token);

--- a/test/unit/will_options_test.h
+++ b/test/unit/will_options_test.h
@@ -24,6 +24,7 @@
 #include <cppunit/extensions/HelperMacros.h>
 
 #include "mqtt/will_options.h"
+#include "mqtt/qos.h"
 
 #include "dummy_async_client.h"
 
@@ -50,13 +51,13 @@ class will_options_test : public CppUnit::TestFixture
 	CPPUNIT_TEST_SUITE_END();
 
 	const std::string EMPTY_STR;
-	const int DFLT_QOS = 0;
+	const mqtt::QoS DFLT_QOS = mqtt::QoS::QOS0;
 
 	const std::string TOPIC = "hello";
 	const char* BUF = "Hello there";
 	const size_t N = std::strlen(BUF);
 	const std::string PAYLOAD = std::string(BUF);
-	const int QOS = 1;
+	const mqtt::QoS QOS = mqtt::QoS::QOS1;
 
 	mqtt::will_options orgOpts;
 


### PR DESCRIPTION
Convert to integer only in the interface with Paho MQTT C. This ensures that QoS will be used consciously. And the user will not provide an arbitrary integer instead of a QoS value.
```
      +-----------------+
      |                 |
      |  Paho MQTT C++  | <-- Use only QoS enumeration
      |                 |
      +-----------------+ <-- Conversion between QoS enum and int
      |                 |
      |   Paho MQTT C   | <-- Deal with interger QoS
      |                 |
      +-----------------+
```

The `mqtt::QoS` enumerators have `sizeof(int)` because an array of QoS might be cast to an array of integers. Thus, each element must have the same size.