### PR TITLE
Fix exception message

### DIFF
--- a/src/mqtt/exception.h
+++ b/src/mqtt/exception.h
@@ -46,10 +46,15 @@ class exception : public std::runtime_error
 {
 	/** The error code from the C library */
 	int code_;
+	std::string msg_;
 
 public:
 	explicit exception(int reasonCode) : std::runtime_error("mqtt::exception"),
-											code_(reasonCode) {}
+											code_(reasonCode),
+											msg_("MQTT exception ") {
+		msg_ += std::to_string(code_);
+
+	}
 	/**
 	 * Returns the detail message for this exception.
 	 */
@@ -68,7 +73,7 @@ public:
 	 * @return const char* 
 	 */
 	virtual const char* what() const noexcept {
-		return (std::string("MQTT exception ")+std::to_string(code_)).c_str();
+		return msg_.c_str();
 	}
 };
 


### PR DESCRIPTION
The temporary `std::string` created inside` exception::what()` might get destructed right after the method returns. Thus, the char array returned by `c_str()` is invalid.

During the test cases we get:

```
!!!FAILURES!!!
Test Results:
Run:  147   Failures: 3   Errors: 0

1) test: exception_test::test_get_message (F) line: 69 exception_test.h
equality assertion failed
- Expected: MQTT exception -1
- Actual  : �o��

2) test: exception_test::test_to_str (F) line: 90 exception_test.h
equality assertion failed
- Expected: MQTT exception -1
- Actual  : �|��
```

This solution creates an `std::string` that has the same life span as the `mqtt::exception` object that holds it.

Any comments? 