### PR TITLE
Prepare the ssl_options class to be tested

### DIFF
--- a/src/mqtt/ssl_options.h
+++ b/src/mqtt/ssl_options.h
@@ -84,6 +84,27 @@ public:
 	 */
 	ssl_options();
 	/**
+	 * Argument constructor.
+	 * @param trustStore The file containing the public digital certificates
+	 * trusted by the client.
+	 * @param keyStore The file containing the public certificate chain of the
+	 * client.
+	 * @param privateKey The file containing the client's private key.
+	 * @param privateKeyPassword The password to load the client's privateKey
+	 * if encrypted.
+	 * @param enabledCipherSuites The list of cipher suites that the client
+	 * will present to the server during the SSL handshake.
+	 * @param enableServerCertAuth True/False option to enable verification of
+	 * the server certificate
+	 */
+	ssl_options(
+			const std::string& trustStore,
+			const std::string& keyStore,
+			const std::string& privateKey,
+			const std::string& privateKeyPassword,
+			const std::string& enabledCipherSuites,
+			const bool enableServerCertAuth);
+	/**
 	 * Copy constructor.
 	 * @param opt The other options to copy.
 	 */

--- a/src/ssl_options.cpp
+++ b/src/ssl_options.cpp
@@ -79,6 +79,10 @@ ssl_options::ssl_options(ssl_options&& opt)
 	opts_.privateKey = privateKey_.empty() ? nullptr : privateKey_.c_str();
 	opts_.privateKeyPassword = privateKeyPassword_.empty() ? nullptr : privateKeyPassword_.c_str();
 	opts_.enabledCipherSuites = enabledCipherSuites_.empty() ? nullptr : enabledCipherSuites_.c_str();
+
+	// NOTE: leave the source object "empty" (i.e. with default values)
+	MQTTAsync_SSLOptions dfltSSLOpt = MQTTAsync_SSLOptions_initializer;
+	std::memcpy(&opt.opts_, &dfltSSLOpt, sizeof(opt.opts_));
 }
 
 ssl_options& ssl_options::operator=(const ssl_options& rhs)
@@ -119,9 +123,10 @@ ssl_options& ssl_options::operator=(ssl_options&& rhs)
 	privateKeyPassword_ = std::move(rhs.privateKeyPassword_);
 	enabledCipherSuites_ = std::move(rhs.enabledCipherSuites_);
 
-	// OPTIMIZE: We probably don't need to do any of the following,
-	// but just to be safe
-	std::memset(&rhs.opts_, 0, sizeof(MQTTAsync_SSLOptions));
+	// NOTE: the correct semantic is to leave the source object
+	// "empty" (i.e. with default values)
+	MQTTAsync_SSLOptions dfltSSLOpt = MQTTAsync_SSLOptions_initializer;
+	std::memcpy(&rhs.opts_, &dfltSSLOpt, sizeof(rhs.opts_));
 
 	// NOTE: By default, the Paho C treats nullptr char arrays as unset values,
 	// so we keep that semantic and only set those char arrays if the string

--- a/src/ssl_options.cpp
+++ b/src/ssl_options.cpp
@@ -28,6 +28,28 @@ ssl_options::ssl_options() : opts_(MQTTAsync_SSLOptions_initializer)
 {
 }
 
+ssl_options::ssl_options(
+		const std::string& trustStore,
+		const std::string& keyStore,
+		const std::string& privateKey,
+		const std::string& privateKeyPassword,
+		const std::string& enabledCipherSuites,
+		const bool enableServerCertAuth)
+		: opts_(MQTTAsync_SSLOptions_initializer),
+		  trustStore_(trustStore),
+		  keyStore_(keyStore),
+		  privateKey_(privateKey),
+		  privateKeyPassword_(privateKeyPassword),
+		  enabledCipherSuites_(enabledCipherSuites)
+{
+	opts_.trustStore = trustStore_.empty() ? nullptr : trustStore_.c_str();
+	opts_.keyStore = keyStore_.empty() ? nullptr : keyStore_.c_str();
+	opts_.privateKey = privateKey_.empty() ? nullptr : privateKey_.c_str();
+	opts_.privateKeyPassword = privateKeyPassword_.empty() ? nullptr : privateKeyPassword_.c_str();
+	opts_.enabledCipherSuites = enabledCipherSuites_.empty() ? nullptr : enabledCipherSuites_.c_str();
+	opts_.enableServerCertAuth = enableServerCertAuth;
+}
+
 ssl_options::ssl_options(const ssl_options& opt)
 		: opts_(opt.opts_), trustStore_(opt.trustStore_), keyStore_(opt.keyStore_),
 			privateKey_(opt.privateKey_), privateKeyPassword_(opt.privateKeyPassword_),


### PR DESCRIPTION
Prepare the `ssl_options` class to be tested. It adds an argument constructor and changes the semantics of the move constructor/assignment.