### PR TITLE
Reduce the required CMake version from 3.1 to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,10 +17,13 @@
 ## Note: on OS X you should install XCode and the associated command-line tools
 
 ## cmake flags
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 ## project name
-project("paho-mqtt-cpp" LANGUAGES CXX)
+project("paho-mqtt-cpp")
+
+## project language
+enable_language(CXX)
 
 ## library name
 set(PAHO_MQTT_CPP paho-mqttpp3)


### PR DESCRIPTION
Replace the `LANGUAGES` directive, from the `project()` command, by the `enable_language()` command.