### PR TITLE
CMake builds against Paho C development tree

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,10 +96,20 @@ if(PAHO_BUILD_STATIC)
 endif()
 
 ## extract Paho MQTT C include directory
-get_filename_component(PAHO_MQTT_C_INC_DIR ${PAHO_MQTT_C_PATH}/include ABSOLUTE)
+get_filename_component(PAHO_MQTT_C_DEV_INC_DIR ${PAHO_MQTT_C_PATH}/src ABSOLUTE)
+get_filename_component(PAHO_MQTT_C_STD_INC_DIR ${PAHO_MQTT_C_PATH}/include ABSOLUTE)
+set(PAHO_MQTT_C_INC_DIR
+    ${PAHO_MQTT_C_DEV_INC_DIR}
+    ${PAHO_MQTT_C_STD_INC_DIR})
 
 ## extract Paho MQTT C library directory
-get_filename_component(PAHO_MQTT_C_LIB_DIR ${PAHO_MQTT_C_PATH}/lib ABSOLUTE)
+get_filename_component(PAHO_MQTT_C_DEV_LIB_DIR ${PAHO_MQTT_C_PATH}/build/output ABSOLUTE)
+get_filename_component(PAHO_MQTT_C_STD_LIB_DIR ${PAHO_MQTT_C_PATH}/lib ABSOLUTE)
+get_filename_component(PAHO_MQTT_C_STD64_LIB_DIR ${PAHO_MQTT_C_PATH}/lib64 ABSOLUTE)
+set(PAHO_MQTT_C_LIB_DIR
+    ${PAHO_MQTT_C_DEV_LIB_DIR}
+    ${PAHO_MQTT_C_STD_LIB_DIR}
+    ${PAHO_MQTT_C_STD64_LIB_DIR})
 
 ## extract Paho MQTT C binary directory (Windows may place libraries there)
 get_filename_component(PAHO_MQTT_C_BIN_DIR ${PAHO_MQTT_C_PATH}/bin ABSOLUTE)


### PR DESCRIPTION
Fix issue  #67. 

Allow CMake to work with Paho MQTT C development builds. The headers and the library are not in standard directories, `${PAHO_MQTT_C_PATH}/include` and `${PAHO_MQTT_C_PATH}/lib`, respectively. Instead, in the Paho MQTT C development building, the headers are in `${PAHO_MQTT_C_PATH}/src` and the libraries are in `${PAHO_MQTT_C_PATH}/build/output`.

Tested with
- CMake version 2.8.12
- GNU GCC 4.8.2

Signed-off-by: Guilherme Maciel Ferreira <guilherme.maciel.ferreira@gmail.com>