### PR TITLE
CMake builds "samples" against Paho C development tree

### DIFF
--- a/src/samples/CMakeLists.txt
+++ b/src/samples/CMakeLists.txt
@@ -17,7 +17,11 @@
 ## Note: on OS X you should install XCode and the associated command-line tools
 
 ## Paho MQTT C include directory
-get_filename_component(PAHO_MQTT_C_INC_DIR ${PAHO_MQTT_C_PATH}/include ABSOLUTE)
+get_filename_component(PAHO_MQTT_C_DEV_INC_DIR ${PAHO_MQTT_C_PATH}/src ABSOLUTE)
+get_filename_component(PAHO_MQTT_C_STD_INC_DIR ${PAHO_MQTT_C_PATH}/include ABSOLUTE)
+set(PAHO_MQTT_C_INC_DIR
+    ${PAHO_MQTT_C_DEV_INC_DIR}
+    ${PAHO_MQTT_C_STD_INC_DIR})
 
 ## Paho MQTT C++ include directory
 get_filename_component(PAHO_MQTT_CPP_INC_DIR ${CMAKE_SOURCE_DIR}/src ABSOLUTE)


### PR DESCRIPTION
Allow CMake to work with Paho MQTT C development builds. The Paho MQTT C headers are not in the standard `include` directory. Instead, in the Paho MQTT C development building, the headers are in `${PAHO_MQTT_C_PATH}/src`.

The library path is already resolved in `PAHO_MQTT_C_LIB` global variable.

Tested with
- CMake 3.4.1, 2.8.12
- GNU GCC 5.3.1