### PR TITLE
Fix the Autotools' compilation when SSL support is disabled

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -41,8 +41,20 @@ if PAHO_WITH_SSL
 libpaho_mqttpp3_la_SOURCES += src/ssl_options.cpp
 endif
 
+
 ###############################################################################
-# Library compiler flags
+# Library: proprocessor flags
+###############################################################################
+
+COMMONCPPFLAGS  = $(AM_CPPFLAGS)
+if PAHO_WITH_SSL
+COMMONCPPFLAGS += -DOPENSSL
+endif
+
+libpaho_mqttpp3_la_CPPFLAGS  = $(COMMONCPPFLAGS)
+
+###############################################################################
+# Library: compiler flags
 ###############################################################################
 
 libpaho_mqttpp3_la_CXXFLAGS  = $(CXXFLAGS)
@@ -111,6 +123,16 @@ async_subscribe_SOURCES = src/samples/async_subscribe.cpp
 sync_publish_SOURCES = src/samples/sync_publish.cpp
 
 ###############################################################################
+# Samples: proprocessor flags
+###############################################################################
+
+async_publish_CPPFLAGS = $(COMMONCPPFLAGS)
+
+async_subscribe_CPPFLAGS = $(COMMONCPPFLAGS)
+
+sync_publish_CPPFLAGS = $(COMMONCPPFLAGS)
+
+###############################################################################
 # Samples: compiler flags
 ###############################################################################
 
@@ -152,6 +174,12 @@ TESTS = $(check_PROGRAMS)
 ###############################################################################
 
 mqttpp_unittest_SOURCES = test/unit/test.cpp
+
+###############################################################################
+# Test: preprocessor flags
+###############################################################################
+
+mqttpp_unittest_CPPFLAGS  = $(COMMONCPPFLAGS)
 
 ###############################################################################
 # Test: compiler flags

--- a/src/connect_options.cpp
+++ b/src/connect_options.cpp
@@ -36,14 +36,18 @@ connect_options::connect_options(const std::string& userName, const std::string&
 connect_options::connect_options(const connect_options& opt) : opts_(opt.opts_)
 {
 	set_will(opt.will_);
+#if defined(OPENSSL)
 	set_ssl(opt.ssl_);
+#endif
 	set_user_name(opt.userName_);
 	set_password(opt.password_);
 }
 
 connect_options::connect_options(connect_options&& opt) : opts_(opt.opts_),
 						will_(std::move(opt.will_)),
+#if defined(OPENSSL)
 						ssl_(std::move(opt.ssl_)),
+#endif
 						userName_(std::move(opt.userName_)),
 						password_(std::move(opt.password_))
 {
@@ -67,11 +71,13 @@ void connect_options::set_will(const will_options& will)
 	opts_.will = &will_.opts_;
 }
 
+#if defined(OPENSSL)
 void connect_options::set_ssl(const ssl_options& ssl)
 {
 	ssl_ = ssl;
 	opts_.ssl = &ssl_.opts_;
 }
+#endif
 
 void connect_options::set_context(token* tok) 
 {

--- a/src/mqtt/connect_options.h
+++ b/src/mqtt/connect_options.h
@@ -28,7 +28,9 @@
 #include "mqtt/message.h"
 #include "mqtt/topic.h"
 #include "mqtt/will_options.h"
+#if defined(OPENSSL)
 #include "mqtt/ssl_options.h"
+#endif
 #include "mqtt/token.h"
 #include <string>
 #include <vector>
@@ -54,8 +56,10 @@ class connect_options
 	/** The LWT options */
 	will_options will_;
 
+#if defined(OPENSSL)
 	/** The SSL options  */
 	ssl_options ssl_;
+#endif
 
 	/** The user name to use for the connection. */
 	std::string userName_;
@@ -129,11 +133,13 @@ public:
 	 * @return The LWT options to use for the connection.
 	 */
 	const will_options& get_will_options() const { return will_; }
+#if defined(OPENSSL)
 	/**
 	 * Get the SSL options to use for the connection.
 	 * @return The SSL options to use for the connection.
 	 */
 	const ssl_options& get_ssl_options() const { return ssl_; }
+#endif
 	/**
 	 * Returns whether the server should remember state for the client
 	 * across reconnects.
@@ -185,11 +191,13 @@ public:
 	 * @param will The LWT options.
 	 */
 	void set_will(const will_options& will);
+#if defined(OPENSSL)
 	/**
 	 * Sets the SSL for the connection.
 	 * @param ssl The SSL options.
 	 */
 	void set_ssl(const ssl_options& ssl);
+#endif
 	/**
 	 * Sets the callback context to a delivery token.
 	 * @param tok The delivery token to be used as the callback context.

--- a/test/unit/ssl_options_test.h
+++ b/test/unit/ssl_options_test.h
@@ -30,6 +30,8 @@ namespace mqtt {
 
 /////////////////////////////////////////////////////////////////////////////
 
+#if defined(OPENSSL)
+
 class ssl_options_test : public CppUnit::TestFixture
 {
 	CPPUNIT_TEST_SUITE( ssl_options_test );
@@ -310,6 +312,8 @@ public:
 		CPPUNIT_ASSERT(c_struct.enabledCipherSuites == nullptr);
 	}
 };
+
+#endif // OPENSSL
 
 /////////////////////////////////////////////////////////////////////////////
 } // end namespace mqtt

--- a/test/unit/test.cpp
+++ b/test/unit/test.cpp
@@ -38,7 +38,9 @@ using namespace CppUnit;
 int main(int argc, char* argv[])
 {
 	CPPUNIT_TEST_SUITE_REGISTRATION( mqtt::will_options_test );
+#if defined(OPENSSL)
 	CPPUNIT_TEST_SUITE_REGISTRATION( mqtt::ssl_options_test );
+#endif // OPENSSL
 	CPPUNIT_TEST_SUITE_REGISTRATION( mqtt::connect_options_test );
 	CPPUNIT_TEST_SUITE_REGISTRATION( mqtt::disconnect_options_test );
 	CPPUNIT_TEST_SUITE_REGISTRATION( mqtt::response_options_test );


### PR DESCRIPTION
The Autotools' build was not passing the `OPENSSL` flag to the compiler. This was causing a lot of compilation and linking problems if the SSL support was disabled (`./configure --without-ssl`). For instance, in the samples:

```
$ ./configure --with-paho-mqtt-c=/tmp/paho-c/ --enable-samples --without-ssl
$ make
make[1]: Entering directory `/home/travis/build/guilhermeferreira/paho.mqtt.cpp/build_autotools'
  CXX      src/libpaho_mqttpp3_la-async_client.lo
  CXX      src/libpaho_mqttpp3_la-client.lo
  CXX      src/libpaho_mqttpp3_la-disconnect_options.lo
  CXX      src/libpaho_mqttpp3_la-iclient_persistence.lo
  CXX      src/libpaho_mqttpp3_la-message.lo
  CXX      src/libpaho_mqttpp3_la-response_options.lo
  CXX      src/libpaho_mqttpp3_la-token.lo
  CXX      src/libpaho_mqttpp3_la-topic.lo
  CXX      src/libpaho_mqttpp3_la-connect_options.lo
  CXX      src/libpaho_mqttpp3_la-will_options.lo
  CXXLD    libpaho-mqttpp3.la
  CXX      src/samples/async_publish-async_publish.o
  CXXLD    async_publish
./.libs/libpaho-mqttpp3.so: undefined reference to `mqtt::ssl_options::ssl_options()'
./.libs/libpaho-mqttpp3.so: undefined reference to `mqtt::ssl_options::operator=(mqtt::ssl_options const&)'
./.libs/libpaho-mqttpp3.so: undefined reference to `mqtt::ssl_options::ssl_options(mqtt::ssl_options&&)'
```

And in the test cases:

```
$ ./configure --with-paho-mqtt-c=/tmp/paho-c/ --disable-samples --without-ssl
$ make check
...
make  mqttpp-unittest
make[1]: Entering directory `/home/travis/build/guilhermeferreira/paho.mqtt.cpp/build_autotools'
  CXX      test/unit/mqttpp_unittest-test.o
  CXXLD    mqttpp-unittest
mqttpp_unittest-test.o: In function `ssl_options_test::test_copy_constructor()':
  ssl_options_test.h:113: undefined reference to `ssl_options_test::test_copy_constructor()':
mqttpp_unittest-test.o: In function `ssl_options_test::test_move_assignment()':
  ssl_options_test.h:208: undefined reference to `ssl_options::ssl_options()'
  ssl_options_test.h:210: undefined reference to `ssl_options::operator=(mqtt::ssl_options&&)'
  ssl_options_test.h:228: undefined reference to `ssl_options::operator=(mqtt::ssl_options&&)'
```