### PR TITLE
Fix issue #70: CMake specifies -std=c++11 for older compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,10 +44,28 @@ set(PAHO_BUILD_SAMPLES FALSE CACHE BOOL "Build sample programs")
 set(PAHO_BUILD_DOCUMENTATION FALSE CACHE BOOL "Create and install the HTML based API documentation (requires Doxygen)")
 set(PAHO_MQTT_C_PATH "" CACHE PATH "Add a path to paho.mqtt.c library and headers")
 set(PAHO_MQTT_C paho-mqtt3a)
-SET(PAHO_WITH_SSL TRUE CACHE BOOL "Flag that defines whether to build ssl-enabled binaries too. ")
+set(PAHO_WITH_SSL TRUE CACHE BOOL "Flag that defines whether to build ssl-enabled binaries too. ")
 
 ## build flags
-set(CMAKE_CXX_STANDARD 11)
+## for GCC
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # GCC versions older than 4.8 do not compile the code
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.8)
+        message(FATAL_ERROR "Minimum GCC version required is 4.8")
+    # GCC versions prior to 6.1 require -std=c++11
+    elseif (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.1)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    endif()
+# for Clang
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    # Clang versions older than 3.3 do not compile the code
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.3)
+        message(FATAL_ERROR "Minimum Clang version required is 3.3")
+    # Clang versions prior to 5.0 require -std=c++11
+    elseif (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    endif()
+endif()
 
 ## build directories
 


### PR DESCRIPTION
Remove the `CMAKE_CXX_STANDARD` flag. It's supported only by CMake versions newer than 3.1. And since commit ebacf0eb the CMake version required dropped from 3.1 to 2.8.12.

Set the minimum required GCC version to 4.8 [1][3]. This is the first GCC version to fully support the C++11 concurrency [1][2]. GCC versions prior to 6.1 default to C++98. Thus, they require the -std=c++11 command-line flag to compile C++11 code.

Set the minimum required Clang version to 3.3 [4]. Clang versions prior to 5.0 default to C++98. Thus, they require the -std=c++11 command-line flag to compile C++11 code.

The minimum required Visual Studio C++ version is 2015 [5]. However, due to the lack of Visual Studio compilers available to us, we postpone to later commits.

[1] https://gcc.gnu.org/projects/cxx-status.html
[2] https://gcc.gnu.org/gcc-4.7/cxx0x_status.html
[3] https://gcc.gnu.org/gcc-4.8/cxx0x_status.html
[4] https://clang.llvm.org/cxx_status.html
[5] https://msdn.microsoft.com/en-us/library/hh567368.aspx