### PR TITLE
Buffer reference template class, 'buffer_ref'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -78,6 +78,7 @@ libpaho_mqttpp3_la_LDFLAGS += $(LIBS)
 ###############################################################################
 
 include_HEADERS  = src/mqtt/async_client.h
+include_HEADERS += src/mqtt/buffer_ref.h
 include_HEADERS += src/mqtt/callback.h
 include_HEADERS += src/mqtt/client.h
 include_HEADERS += src/mqtt/connect_options.h

--- a/src/async_client.cpp
+++ b/src/async_client.cpp
@@ -32,7 +32,7 @@ namespace mqtt {
 
 /////////////////////////////////////////////////////////////////////////////
 
-async_client::async_client(const std::string& serverURI, const std::string& clientId)
+async_client::async_client(const string& serverURI, const string& clientId)
 				: serverURI_(serverURI), clientId_(clientId),
 					persist_(nullptr), userCallback_(nullptr)
 {
@@ -41,8 +41,8 @@ async_client::async_client(const std::string& serverURI, const std::string& clie
 }
 
 
-async_client::async_client(const std::string& serverURI, const std::string& clientId,
-						   const std::string& persistDir)
+async_client::async_client(const string& serverURI, const string& clientId,
+						   const string& persistDir)
 				: serverURI_(serverURI), clientId_(clientId),
 					persist_(nullptr), userCallback_(nullptr)
 {
@@ -50,7 +50,7 @@ async_client::async_client(const std::string& serverURI, const std::string& clie
 					 MQTTCLIENT_PERSISTENCE_DEFAULT, const_cast<char*>(persistDir.c_str()));
 }
 
-async_client::async_client(const std::string& serverURI, const std::string& clientId,
+async_client::async_client(const string& serverURI, const string& clientId,
 						   iclient_persistence* persistence)
 				: serverURI_(serverURI), clientId_(clientId),
 					persist_(nullptr), userCallback_(nullptr)
@@ -95,7 +95,7 @@ void async_client::on_connection_lost(void *context, char *cause)
 		async_client* cli = static_cast<async_client*>(context);
 		callback* cb = cli->get_callback();
 		if (cb)
-			cb->connection_lost(cause ? std::string(cause) : std::string());
+			cb->connection_lost(cause ? string(cause) : string());
 	}
 }
 
@@ -106,7 +106,7 @@ int async_client::on_message_arrived(void* context, char* topicName, int topicLe
 		async_client* cli = static_cast<async_client*>(context);
 		callback* cb = cli->get_callback();
 		if (cb) {
-			std::string topic(topicName, topicName+topicLen);
+			string topic(topicName, topicName+topicLen);
 			const_message_ptr m = std::make_shared<message>(*msg);
 			cb->message_arrived(topic, m);
 		}
@@ -360,14 +360,14 @@ std::vector<idelivery_token_ptr> async_client::get_pending_delivery_tokens() con
 // --------------------------------------------------------------------------
 // Publish
 
-idelivery_token_ptr async_client::publish(const std::string& topic, const void* payload,
+idelivery_token_ptr async_client::publish(const string& topic, const void* payload,
 										  size_t n, int qos, bool retained)
 {
 	auto msg = make_message(payload, n, qos, retained);
 	return publish(topic, msg);
 }
 
-idelivery_token_ptr async_client::publish(const std::string& topic,
+idelivery_token_ptr async_client::publish(const string& topic,
 										  const void* payload, size_t n,
 										  int qos, bool retained, void* userContext,
 										  iaction_listener& cb)
@@ -376,7 +376,7 @@ idelivery_token_ptr async_client::publish(const std::string& topic,
 	return publish(topic, msg, userContext, cb);
 }
 
-idelivery_token_ptr async_client::publish(const std::string& topic, const_message_ptr msg)
+idelivery_token_ptr async_client::publish(const string& topic, const_message_ptr msg)
 {
 	idelivery_token_ptr tok = delivery_token::create(*this, topic, msg);
 	add_token(tok);
@@ -400,7 +400,7 @@ idelivery_token_ptr async_client::publish(const std::string& topic, const_messag
 	return tok;
 }
 
-idelivery_token_ptr async_client::publish(const std::string& topic, const_message_ptr msg,
+idelivery_token_ptr async_client::publish(const string& topic, const_message_ptr msg,
 										  void* userContext, iaction_listener& cb)
 {
 	idelivery_token_ptr tok = delivery_token::create(*this, topic, msg);
@@ -504,7 +504,7 @@ itoken_ptr async_client::subscribe(const topic_filter_collection& topicFilters,
 	return tok;
 }
 
-itoken_ptr async_client::subscribe(const std::string& topicFilter, int qos)
+itoken_ptr async_client::subscribe(const string& topicFilter, int qos)
 {
 	itoken_ptr tok = token::create(*this, topicFilter);
 	add_token(tok);
@@ -521,7 +521,7 @@ itoken_ptr async_client::subscribe(const std::string& topicFilter, int qos)
 	return tok;
 }
 
-itoken_ptr async_client::subscribe(const std::string& topicFilter, int qos,
+itoken_ptr async_client::subscribe(const string& topicFilter, int qos,
 								   void* userContext, iaction_listener& cb)
 {
 	itoken_ptr tok = token::create(*this, topicFilter);
@@ -544,7 +544,7 @@ itoken_ptr async_client::subscribe(const std::string& topicFilter, int qos,
 // --------------------------------------------------------------------------
 // Unsubscribe
 
-itoken_ptr async_client::unsubscribe(const std::string& topicFilter)
+itoken_ptr async_client::unsubscribe(const string& topicFilter)
 {
 	itoken_ptr tok = token::create(*this, topicFilter);
 	add_token(tok);
@@ -606,7 +606,7 @@ itoken_ptr async_client::unsubscribe(const topic_filter_collection& topicFilters
 	return tok;
 }
 
-itoken_ptr async_client::unsubscribe(const std::string& topicFilter,
+itoken_ptr async_client::unsubscribe(const string& topicFilter,
 									 void* userContext, iaction_listener& cb)
 {
 	itoken_ptr tok = token::create(*this, topicFilter);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -28,18 +28,18 @@ const int client::DFLT_QOS = 1;
 
 /////////////////////////////////////////////////////////////////////////////
 
-client::client(const std::string& serverURI, const std::string& clientId)
+client::client(const string& serverURI, const string& clientId)
 			: cli_(serverURI, clientId), timeout_(-1)
 {
 }
 
-client::client(const std::string& serverURI, const std::string& clientId,
-			   const std::string& persistDir)
+client::client(const string& serverURI, const string& clientId,
+			   const string& persistDir)
 			: cli_(serverURI, clientId, persistDir), timeout_(-1)
 {
 }
 
-client::client(const std::string& serverURI, const std::string& clientId,
+client::client(const string& serverURI, const string& clientId,
 			   iclient_persistence* persistence)
 			: cli_(serverURI, clientId, persistence), timeout_(-1)
 {
@@ -70,16 +70,16 @@ void client::disconnect(int timeout)
 	cli_.disconnect(timeout)->wait_for_completion(timeout_);
 }
 
-//std::string client::generate_client_id()
+//string client::generate_client_id()
 //{
 //}
 
-std::string client::get_client_id() const
+string client::get_client_id() const
 {
 	return cli_.get_client_id();
 }
 
-std::string client::get_server_uri() const
+string client::get_server_uri() const
 {
 	return cli_.get_server_uri();
 }
@@ -97,7 +97,7 @@ int client::get_time_to_wait() const
 	return timeout_;
 }
 
-topic client::get_topic(const std::string& top)
+topic client::get_topic(const string& top)
 {
 	return topic(top, cli_);
 }
@@ -107,18 +107,18 @@ bool client::is_connected() const
 	return cli_.is_connected();
 }
 
-void client::publish(const std::string& top, const void* payload, size_t n,
+void client::publish(const string& top, const void* payload, size_t n,
 					 int qos, bool retained)
 {
 	cli_.publish(top, payload, n, qos, retained)->wait_for_completion(timeout_);
 }
 
-void client::publish(const std::string& top, const_message_ptr msg)
+void client::publish(const string& top, const_message_ptr msg)
 {
 	cli_.publish(top, msg)->wait_for_completion(timeout_);
 }
 
-void client::publish(const std::string& top, const message& msg)
+void client::publish(const string& top, const message& msg)
 {
 	// Don't destroy non-heap message.
 	std::shared_ptr<message> msgp(const_cast<message*>(&msg), [](message*){});
@@ -135,7 +135,7 @@ void client::set_time_to_wait(int timeout)
 	timeout_ = timeout;
 }
 
-void client::subscribe(const std::string& topicFilter)
+void client::subscribe(const string& topicFilter)
 {
 	cli_.subscribe(topicFilter, DFLT_QOS)->wait_for_completion(timeout_);
 }
@@ -155,12 +155,12 @@ void client::subscribe(const topic_filter_collection& topicFilters,
 	cli_.subscribe(topicFilters, qos)->wait_for_completion(timeout_);
 }
 
-void client::subscribe(const std::string& topicFilter, int qos)
+void client::subscribe(const string& topicFilter, int qos)
 {
 	cli_.subscribe(topicFilter, qos)->wait_for_completion(timeout_);
 }
 
-void client::unsubscribe(const std::string& topicFilter)
+void client::unsubscribe(const string& topicFilter)
 {
 	cli_.unsubscribe(topicFilter)->wait_for_completion(timeout_);
 }

--- a/src/connect_options.cpp
+++ b/src/connect_options.cpp
@@ -28,7 +28,7 @@ connect_options::connect_options() : opts_(DFLT_C_STRUCT)
 {
 }
 
-connect_options::connect_options(const std::string& userName, const std::string& password)
+connect_options::connect_options(string_ref userName, binary_ref password)
 		: connect_options()
 {
 	set_user_name(userName);
@@ -116,15 +116,15 @@ void connect_options::set_will(const will_options& will)
 	opts_.will = &will_.opts_;
 }
 
-void connect_options::set_user_name(const std::string& userName)
+void connect_options::set_user_name(string_ref userName)
 {
-	userName_ = userName;
+	userName_ = std::move(userName);
 	opts_.username = c_str(userName_);
 }
 
-void connect_options::set_password(const byte_buffer& password)
+void connect_options::set_password(binary_ref password)
 {
-	password_ = password;
+	password_ = std::move(password);
 
 	if (password_.empty()) {
 		opts_.binarypwd.len = 0;

--- a/src/iclient_persistence.cpp
+++ b/src/iclient_persistence.cpp
@@ -114,7 +114,7 @@ int iclient_persistence::persistence_put(void* handle, char* key, int bufcount,
 				p = std::make_shared<persistence_wrapper>(buffers[0], buflens[0],
 														  buffers[1], buflens[1]);
 			else {
-				std::string buf;
+				string buf;
 				for (int i=0; i<bufcount; ++i) {
 					if (buffers[i] && buflens[i] > 0)
 						buf.append(buffers[i], buflens[i]);
@@ -176,7 +176,7 @@ int iclient_persistence::persistence_keys(void* handle, char*** keys, int* nkeys
 {
 	try {
 		if (handle && keys && nkeys) {
-			std::vector<std::string> k(
+			std::vector<string> k(
 				static_cast<iclient_persistence*>(handle)->keys());
 			size_t n = k.size();
 			*nkeys = n;		// TODO: Check range

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -33,9 +33,10 @@ constexpr MQTTAsync_message message::DFLT_C_STRUCT;
 
 message::message() : msg_(DFLT_C_STRUCT)
 {
+	set_payload(string());
 }
 
-message::message(const void* payload, size_t len, int qos/*=DFLT_QOS*/, bool retained/*=DFLT_RETAINED*/)
+message::message(const void* payload, size_t len, int qos, bool retained)
 						: msg_(DFLT_C_STRUCT)
 {
 	set_payload(payload, len);
@@ -43,22 +44,22 @@ message::message(const void* payload, size_t len, int qos/*=DFLT_QOS*/, bool ret
 	set_retained(retained);
 }
 
-message::message(byte_buffer payload, int qos/*=DFLT_QOS*/, bool retained/*=DFLT_RETAINED*/)
+message::message(binary_ref payload, int qos, bool retained)
 						: msg_(DFLT_C_STRUCT)
 {
 	set_payload(std::move(payload));
 	set_qos(qos);
 	set_retained(retained);
 }
-
-message::message(const std::string& payload, int qos/*=DFLT_QOS*/, bool retained/*=DFLT_RETAINED*/)
+#if 0
+message::message(const string& payload, int qos, bool retained)
 						: msg_(DFLT_C_STRUCT)
 {
 	set_payload(payload);
 	set_qos(qos);
 	set_retained(retained);
 }
-
+#endif
 message::message(const MQTTAsync_message& msg) : msg_(msg)
 {
 	set_payload(msg.payload, msg.payloadlen);
@@ -97,21 +98,21 @@ message& message::operator=(message&& rhs)
 
 void message::clear_payload()
 {
-	payload_.clear();
+	payload_ = string();	//.reset();
 	msg_.payload = nullptr;
 	msg_.payloadlen = 0;
 }
 
-void message::set_payload(byte_buffer payload)
+void message::set_payload(binary_ref payload)
 {
 	payload_ = std::move(payload);
 
-	if (payload_.empty()) {
+	if (!payload_ || payload_.empty()) {
 		msg_.payload = nullptr;
 		msg_.payloadlen = 0;
 	}
 	else {
-		msg_.payload = const_cast<byte*>(payload_.data());
+		msg_.payload = const_cast<binary_ref::value_type*>(payload_.data());
 		msg_.payloadlen = payload_.length();
 	}
 }

--- a/src/mqtt/CMakeLists.txt
+++ b/src/mqtt/CMakeLists.txt
@@ -19,6 +19,7 @@
 ## install headers
 set(COMMON_HDR
     async_client.h
+    buffer_ref.h
     callback.h
     client.h
     connect_options.h

--- a/src/mqtt/async_client.h
+++ b/src/mqtt/async_client.h
@@ -25,6 +25,7 @@
 #define __mqtt_async_client_h
 
 #include "MQTTAsync.h"
+#include "mqtt/types.h"
 #include "mqtt/token.h"
 #include "mqtt/delivery_token.h"
 #include "mqtt/iclient_persistence.h"
@@ -33,7 +34,6 @@
 #include "mqtt/message.h"
 #include "mqtt/callback.h"
 #include "mqtt/iasync_client.h"
-#include <string>
 #include <vector>
 #include <list>
 #include <memory>
@@ -42,7 +42,7 @@
 namespace mqtt {
 
 const uint32_t		VERSION = 0x00050000;
-const std::string	VERSION_STR("mqttpp v. 0.5"),
+const string	VERSION_STR("mqttpp v. 0.5"),
 					COPYRIGHT("Copyright (c) 2013-2016 Frank Pagliughi");
 
 /////////////////////////////////////////////////////////////////////////////
@@ -68,9 +68,9 @@ private:
 	/** The underlying C-lib client. */
 	MQTTAsync cli_;
 	/** The server URI string. */
-	std::string serverURI_;
+	string serverURI_;
 	/** The client ID string that we provided to the server. */
-	std::string clientId_;
+	string clientId_;
 	/** A user persistence wrapper (if any) */
 	MQTTClient_persistence* persist_;
 	/** Callback supplied by the user (if any) */
@@ -122,7 +122,7 @@ public:
 	 * @param clientId a client identifier that is unique on the server
 	 *  			   being connected to.
 	 */
-	async_client(const std::string& serverURI, const std::string& clientId);
+	async_client(const string& serverURI, const string& clientId);
 	/**
 	 * Create an async_client that can be used to communicate with an MQTT
 	 * server.
@@ -133,8 +133,8 @@ public:
 	 *  			   being connected to
 	 * @param persistDir
 	 */
-	async_client(const std::string& serverURI, const std::string& clientId,
-				 const std::string& persistDir);
+	async_client(const string& serverURI, const string& clientId,
+				 const string& persistDir);
 	/**
 	 * Create an async_client that can be used to communicate with an MQTT
 	 * server.
@@ -147,7 +147,7 @@ public:
 	 * @param persistence The user persistence structure. If this is null,
 	 *  				  then no persistence is used.
 	 */
-	async_client(const std::string& serverURI, const std::string& clientId,
+	async_client(const string& serverURI, const string& clientId,
 				 iclient_persistence* persistence);
 	/**
 	 * Destructor
@@ -303,12 +303,12 @@ public:
 	 * Returns the client ID used by this client.
 	 * @return The client ID used by this client.
 	 */
-	std::string get_client_id() const override { return clientId_; }
+	string get_client_id() const override { return clientId_; }
 	/**
 	 * Returns the address of the server used by this client.
 	 * @return The server's address, as a URI String.
 	 */
-	std::string get_server_uri() const override { return serverURI_; }
+	string get_server_uri() const override { return serverURI_; }
 	/**
 	 * Determines if this client is currently connected to the server.
 	 * @return true if connected, false otherwise.
@@ -326,7 +326,7 @@ public:
 	 * @return token used to track and wait for the publish to complete. The
 	 *  	   token will be passed to callback methods if set.
 	 */
-	idelivery_token_ptr publish(const std::string& topic, const void* payload,
+	idelivery_token_ptr publish(const string& topic, const void* payload,
 								size_t n, int qos, bool retained) override;
 	/**
 	 * Publishes a message to a topic on the server
@@ -343,7 +343,7 @@ public:
 	 * @return token used to track and wait for the publish to complete. The
 	 *  	   token will be passed to callback methods if set.
 	 */
-	idelivery_token_ptr publish(const std::string& topic,
+	idelivery_token_ptr publish(const string& topic,
 								const void* payload, size_t n,
 								int qos, bool retained, void* userContext,
 								iaction_listener& cb) override;
@@ -356,7 +356,7 @@ public:
 	 * @return token used to track and wait for the publish to complete. The
 	 *  	   token will be passed to callback methods if set.
 	 */
-	idelivery_token_ptr publish(const std::string& topic, const_message_ptr msg) override;
+	idelivery_token_ptr publish(const string& topic, const_message_ptr msg) override;
 	/**
 	 * Publishes a message to a topic on the server.
 	 * @param topic the topic to deliver the message to
@@ -369,7 +369,7 @@ public:
 	 * @return token used to track and wait for the publish to complete. The
 	 *  	   token will be passed to callback methods if set.
 	 */
-	idelivery_token_ptr publish(const std::string& topic, const_message_ptr msg,
+	idelivery_token_ptr publish(const string& topic, const_message_ptr msg,
 								void* userContext, iaction_listener& cb) override;
 	/**
 	 * Sets a callback listener to use for events that happen
@@ -416,7 +416,7 @@ public:
 	 * @return token used to track and wait for the subscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	itoken_ptr subscribe(const std::string& topicFilter, int qos) override;
+	itoken_ptr subscribe(const string& topicFilter, int qos) override;
 	/**
 	 * Subscribe to a topic, which may include wildcards.
 	 * @param topicFilter the topic to subscribe to, which can include
@@ -432,7 +432,7 @@ public:
 	 * @return token used to track and wait for the subscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	itoken_ptr subscribe(const std::string& topicFilter, int qos,
+	itoken_ptr subscribe(const string& topicFilter, int qos,
 						 void* userContext, iaction_listener& cb) override;
 	/**
 	 * Requests the server unsubscribe the client from a topic.
@@ -441,7 +441,7 @@ public:
 	 * @return token used to track and wait for the unsubscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	itoken_ptr unsubscribe(const std::string& topicFilter) override;
+	itoken_ptr unsubscribe(const string& topicFilter) override;
 	/**
 	 * Requests the server unsubscribe the client from one or more topics.
 	 * @param topicFilters one or more topics to unsubscribe from. Each
@@ -474,7 +474,7 @@ public:
 	 * @return token used to track and wait for the unsubscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	itoken_ptr unsubscribe(const std::string& topicFilter,
+	itoken_ptr unsubscribe(const string& topicFilter,
 						   void* userContext, iaction_listener& cb) override;
 };
 

--- a/src/mqtt/buffer_ref.h
+++ b/src/mqtt/buffer_ref.h
@@ -1,0 +1,278 @@
+/////////////////////////////////////////////////////////////////////////////
+/// @file buffer_ref.h
+/// Buffer reference type for the Paho MQTT C++ library.
+/// @date April 18, 2017
+/// @author Frank Pagliughi
+/////////////////////////////////////////////////////////////////////////////
+
+/*******************************************************************************
+ * Copyright (c) 2017 Frank Pagliughi <fpagliughi@mindspring.com>
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *   http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * Contributors:
+ *    Frank Pagliughi - initial implementation and documentation
+ *******************************************************************************/
+
+#ifndef __mqtt_buffer_ref_h
+#define __mqtt_buffer_ref_h
+
+#include "mqtt/types.h"
+#include <iostream>
+#include <cstring>
+
+namespace mqtt {
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * A reference object for holding immutable data buffers, with cheap copy
+ * semantics.
+ *
+ * Each object of this class contains a reference-counted pointer to an
+ * immutable data buffer. Onjects can be copied freely and easily since all
+ * instances promise not to modify the contents of the buffer.
+ *
+ * The buffer is immutable but the reference itself acts like a normal
+ * variable. It can be reassigned to point to a different buffer.
+ */
+template <typename T>
+class buffer_ref
+{
+public:
+	/**
+	 * The underlying type for the buffer.
+	 * Normally byte-wide data (char or uint8_t) for Paho.
+	 */
+	using value_type = T;
+	/**
+	 * The type for the buffer.
+	 * We use basic_string for compatibility with string data.
+	 */
+	using blob = std::basic_string<value_type>;
+	/**
+	 *  The pointer we use.
+	 *  Note that it is a pointer to a _const_ blob.
+	 */
+	using pointer_type = std::shared_ptr<const blob>;
+
+private:
+	/** Our data is a shared pointer to a const buffer */
+	pointer_type data_;
+
+public:
+	/**
+	 * Copy constructor only copies a shared pointer.
+	 * @param buf Another buffer reference.
+	 */
+	buffer_ref(const buffer_ref& buf) =default;
+	/**
+	 * Move constructor only moves a shared pointer.
+	 * @param buf Another buffer reference.
+	 */
+	buffer_ref(buffer_ref&& buf) =default;
+	/**
+	 * Creates a reference to a new buffer by copying data.
+	 * @param b A string from which to create a new buffer.
+	 */
+	buffer_ref(const blob& b) : data_{new blob(b)} {}
+	/**
+	 * Creates a reference to a new buffer by moving a string into the
+	 * buffer.
+	 * @param b A string from which to create a new buffer.
+	 */
+	buffer_ref(blob&& b) : data_{new blob(std::move(b))} {}
+	/**
+	 * Creates a reference to an existing buffer by copying the shared
+	 * pointer.
+	 * Note that it is up to the caller to insure that there are no mutable
+	 * references to the buffer.
+	 * @param p A shared pointer to a string.
+	 */
+	buffer_ref(const pointer_type& p) : data_(p) {}
+	/**
+	 * Creates a reference to an existing buffer by moving the shared
+	 * pointer.
+	 * Note that it is up to the caller to insure that there are no mutable
+	 * references to the buffer.
+	 * @param p A shared pointer to a string.
+	 */
+	buffer_ref(pointer_type&& p) : data_(std::move(p)) {}
+	/**
+	 * Creates a reference to a new buffer containing a copy of the data.
+	 * @param buf The memory to copy
+	 * @param n The number of bytes to copy.
+	 */
+	buffer_ref(const value_type* buf, size_t n) : data_{new blob(buf,n)} {}
+	/**
+	 * Creates a reference to a new buffer containing a copy of the
+	 * NUL-terminated char array.
+	 * @param buf A NUL-terminated char array (C string).
+	 */
+	buffer_ref(const char* buf) : buffer_ref(reinterpret_cast<const value_type*>(buf), std::strlen(buf)) {
+		static_assert(sizeof(char) == sizeof(T), "can only use C arr with char or byte buffers");
+	}
+
+	/*
+	  There are two ways we can handle default construction. One is that we
+	  allow the data_ pointer to use its default and get a null value. That
+	  would be quick and efficient, but leave us with several unsafe
+	  operations that would require null/empty checks for us and/or the
+	  user.
+	  The other option is for the default constructor to create and point to
+	  an empty string. Then all operations are safe and valid, at the
+	  expense of some default construction performance.
+	  It's a tough choice. The first sounds dangerous, but is analagous to
+	  reference types in other languages that default to a "nil" of "null"
+	  value. But the latter creates something closer to a drop-in
+	  replacement for a C++ string
+	*/
+	#if 1
+		buffer_ref() =default;
+		explicit operator bool() const { return bool(data_); }
+		bool empty() const { return !data_ || data_->empty(); }
+	#else
+		buffer_ref() : data_{new blob()} {}
+		bool empty() const { return data_->empty(); }
+	#endif
+
+	/**
+	 * Copy the reference to the buffer.
+	 * @param rhs Another buffer
+	 * @return A reference to this object
+	 */
+	buffer_ref& operator=(const buffer_ref& rhs) =default;
+	/**
+	 * Move a reference to a buffer.
+	 * @param rhs The other reference to move.
+	 * @return A reference to this object.
+	 */
+	buffer_ref& operator=(buffer_ref&& rhs) =default;
+	/**
+	 * Copy a string into this object, creating a new buffer.
+	 * Modifies the reference for this object, pointing it to a
+	 * newly-created buffer. Other references to the old object remain
+	 * unchanges, so this follows copy-on-write semantics.
+	 * @param b A new blob/string to copy.
+	 * @return A reference to this object.
+	 */
+	buffer_ref& operator=(const blob& b) {
+		data_.reset(new blob(b));
+		return *this;
+	}
+	/**
+	 * Move a string into this object, creating a new buffer.
+	 * Modifies the reference for this object, pointing it to a
+	 * newly-created buffer. Other references to the old object remain
+	 * unchanges, so this follows copy-on-write semantics.
+	 * @param b A new blob/string to move.
+	 * @return A reference to this object.
+	 */
+	buffer_ref& operator=(blob&& b) {
+		data_.reset(new blob(std::move(b)));
+		return *this;
+	}
+	/**
+	 * Copy a NUL-terminated C char array into a new buffer
+	 * @param cstr A NUL-terminated C string.
+	 * @return A reference to this object
+	 */
+	buffer_ref& operator=(const char* cstr) {
+		static_assert(sizeof(char) == sizeof(T), "can only use C arr with char or byte buffers");
+		data_.reset(new blob(reinterpret_cast<const value_type*>(cstr), strlen(cstr)));
+		return *this;
+	}
+	/**
+	 * Copy another type of buffer reference to this one.
+	 * This can copy a buffer of different types, provided that the size of
+	 * the data elements are the same. This is typically used to convert
+	 * from char to byte, where the data is the same, but the interpretation
+	 * is different. Note that this copies the underlying buffer.
+	 * @param rhs A reference to a different type of buffer.
+	 * @return A reference to this object.
+	 */
+	template <typename OT>
+	buffer_ref& operator=(const buffer_ref<OT>& rhs) {
+		static_assert(sizeof(OT) == sizeof(T), "Can only assign buffers if values the same size");
+		data_.reset(new blob(reinterpret_cast<const value_type*>(rhs.data()), rhs.size()));
+		return *this;
+	}
+	/**
+	 * Clears the reference to nil.
+	 */
+	void reset() { data_.reset(); }
+	/**
+	 * Get a const pointer to the data buffer.
+	 * @return A pointer to the data buffer.
+	 */
+	const value_type* data() const { return data_ ? data_->data() : nullptr; }
+	/**
+	 * Get the size of the data buffer.
+	 * @return The size of the data buffer.
+	 */
+	size_t size() const { return data_ ? data_->size() : 0; }
+	/**
+	 * Get the size of the data buffer.
+	 * @return The size of the data buffer.
+	 */
+	size_t length() const { return data_ ? data_->length() : 0; }
+	/**
+	 * Get the data buffer as a string.
+	 * @return The data buffer as a string.
+	 */
+	//blob to_string() const { return data_ ? (*data_) : blob(); }
+	const blob& to_string() const { return *data_; }
+	/**
+	 * Get the data buffer as NUL-terminated C string.
+	 * Note that the reference must be set to call this function.
+	 * @return The data buffer as a string.
+	 */
+	const char* c_str() const { return data_->c_str(); }
+	/**
+	 * Gets a shared pointer to the (const) data buffer.
+	 * @return A shared pointer to the (const) data buffer.
+	 */
+	const pointer_type& ptr() const { return data_; }
+	/**
+	 * Gets elemental access to the data buffer (read only)
+	 * @param i The index into the buffer.
+	 * @return The value at the specified index.
+	 */
+	const value_type& operator[](size_t i) const { return (*data_)[i]; }
+};
+
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const buffer_ref<T>& buf) {
+	if (!buf.empty())
+		os.write(buf.data(), buf.size());
+	return os;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * A refernce to a text buffer.
+ */
+using string_ref = buffer_ref<char>;
+
+/**
+ * A reference to a binary buffer.
+ * Note that we're using char for the underlying data type to allow
+ * efficient moves to and from std::string's. Using a separate type
+ * indicates that the data may be arbitrary binary.
+ */
+using binary_ref = buffer_ref<char>;
+
+/////////////////////////////////////////////////////////////////////////////
+// end namespace mqtt
+}
+
+#endif		// __mqtt_buffer_ref_h
+

--- a/src/mqtt/callback.h
+++ b/src/mqtt/callback.h
@@ -26,7 +26,7 @@
 
 #include "MQTTAsync.h"
 #include "mqtt/delivery_token.h"
-#include <string>
+#include "mqtt/types.h"
 #include <vector>
 #include <memory>
 
@@ -54,13 +54,13 @@ public:
 	 * This method is called when the connection to the server is lost.
 	 * @param cause
 	 */
-	virtual void connection_lost(const std::string& cause) =0;
+	virtual void connection_lost(const string& cause) =0;
 	/**
 	 * This method is called when a message arrives from the server.
 	 * @param topic The topic on which the message was published.
 	 * @param msg The message
 	 */
-	virtual void message_arrived(const std::string& topic, const_message_ptr msg) =0;
+	virtual void message_arrived(const string& topic, const_message_ptr msg) =0;
 	/**
 	 * Called when delivery for a message has been completed, and all
 	 * acknowledgments have been received.

--- a/src/mqtt/client.h
+++ b/src/mqtt/client.h
@@ -24,10 +24,8 @@
 #ifndef __mqtt_client_h
 #define __mqtt_client_h
 
-#include "async_client.h"
-
-#include <string>
-#include <memory>
+#include "mqtt/async_client.h"
+#include "mqtt/types.h"
 
 namespace mqtt {
 
@@ -67,7 +65,7 @@ public:
 	 * @param serverURI
 	 * @param clientId
 	 */
-	client(const std::string& serverURI, const std::string& clientId);
+	client(const string& serverURI, const string& clientId);
 	/**
 	 * Create a client that can be used to communicate with an MQTT server.
 	 * This uses file-based persistence in the specified directory.
@@ -75,8 +73,8 @@ public:
 	 * @param clientId
 	 * @param persistDir
 	 */
-	client(const std::string& serverURI, const std::string& clientId,
-		   const std::string& persistDir);
+	client(const string& serverURI, const string& clientId,
+		   const string& persistDir);
 	/**
 	 * Create a client that can be used to communicate with an MQTT server.
 	 * This allows the caller to specify a user-defined persistence object,
@@ -86,7 +84,7 @@ public:
 	 * @param persistence The user persistence structure. If this is null,
 	 *  				  then no persistence is used.
 	 */
-	client(const std::string& serverURI, const std::string& clientId,
+	client(const string& serverURI, const string& clientId,
 		   iclient_persistence* persistence);
 
 	/**
@@ -122,21 +120,21 @@ public:
 	 * Returns a randomly generated client identifier based on the current
 	 * user's login name and the system time.
 	 */
-	//static std::string generate_client_id();
+	//static string generate_client_id();
 	/**
 	 * Returns the client ID used by this client.
-	 * @return std::string
+	 * @return string
 	 */
-	virtual std::string get_client_id() const;
+	virtual string get_client_id() const;
 	/**
 	 * Returns the delivery tokens for any outstanding publish operations.
 	 */
 	virtual std::vector<idelivery_token_ptr> get_pending_delivery_tokens() const;
 	/**
 	 * Returns the address of the server used by this client, as a URI.
-	 * @return std::string
+	 * @return string
 	 */
-	virtual std::string get_server_uri() const;
+	virtual string get_server_uri() const;
 	/**
 	 * Return the maximum time to wait for an action to complete.
 	 * @return int
@@ -147,7 +145,7 @@ public:
 	 * @param tpc
 	 * @return topic
 	 */
-	virtual topic get_topic(const std::string& tpc);
+	virtual topic get_topic(const string& tpc);
 	/**
 	 * Determines if this client is currently connected to the server.
 	 * @return bool
@@ -162,20 +160,20 @@ public:
 	 * @param qos
 	 * @param retained
 	 */
-	virtual void publish(const std::string& top, const void* payload, size_t n,
+	virtual void publish(const string& top, const void* payload, size_t n,
 						 int qos, bool retained);
 	/**
 	 * Publishes a message to a topic on the server.
 	 * @param top The topic to publish on
 	 * @param msg The message
 	 */
-	virtual void publish(const std::string& top, const_message_ptr msg);
+	virtual void publish(const string& top, const_message_ptr msg);
 	/**
 	 * Publishes a message to a topic on the server.
 	 * @param top The topic to publish on
 	 * @param msg The message
 	 */
-	virtual void publish(const std::string& top, const message& msg);
+	virtual void publish(const string& top, const message& msg);
 	/**
 	 * Sets the callback listener to use for events that happen
 	 * asynchronously.
@@ -191,7 +189,7 @@ public:
 	 * Subscribe to a topic, which may include wildcards using a QoS of 1.
 	 * @param topicFilter
 	 */
-	virtual void subscribe(const std::string& topicFilter);
+	virtual void subscribe(const string& topicFilter);
 	/**
 	 * Subscribes to a one or more topics, which may include wildcards using
 	 * a QoS of 1.
@@ -210,12 +208,12 @@ public:
 	 * @param topicFilter A single topic to subscribe
 	 * @param qos The QoS of the subscription
 	 */
-	virtual void subscribe(const std::string& topicFilter, int qos);
+	virtual void subscribe(const string& topicFilter, int qos);
 	/**
 	 * Requests the server unsubscribe the client from a topic.
 	 * @param topicFilter A single topic to unsubscribe.
 	 */
-	virtual void unsubscribe(const std::string& topicFilter);
+	virtual void unsubscribe(const string& topicFilter);
 	/**
 	 * Requests the server unsubscribe the client from one or more topics.
 	 * @param topicFilters A collection of topics to unsubscribe.

--- a/src/mqtt/connect_options.h
+++ b/src/mqtt/connect_options.h
@@ -33,9 +33,7 @@
 #if defined(OPENSSL)
 	#include "mqtt/ssl_options.h"
 #endif
-#include <string>
 #include <vector>
-#include <memory>
 #include <chrono>
 
 namespace mqtt {
@@ -64,10 +62,10 @@ class connect_options
 	#endif
 
 	/** The user name to use for the connection. */
-	std::string userName_;
+	string_ref userName_;
 
 	/** The password to use for the connection. */
-	byte_buffer password_;
+	binary_ref password_;
 
 	/** Shared token pointer for context, if any */
 	token_ptr tok_;
@@ -87,8 +85,8 @@ class connect_options
 	 * @return Pointer to a NUL terminated string. This is only valid until
 	 *  	   the next time the string is updated.
 	 */
-	const char* c_str(const std::string& str) {
-		return str.empty() ? nullptr : str.c_str();
+	const char* c_str(const string_ref& sr) {
+		return sr.empty() ? nullptr : sr.c_str();
 	}
 
 public:
@@ -102,10 +100,11 @@ public:
 	 */
 	connect_options();
 	/**
-	 * Constructs a new object using the specified values.
+	 * Constructs a new object using the specified user name and password.
+	 * @param userName The name of the user for connecting to the server
+	 * @param password The password for connecting to the server
 	 */
-	connect_options(const std::string& userName,
-					const std::string& password);
+	connect_options(string_ref userName, binary_ref password);
 	/**
 	 * Copy constructor.
 	 * @param opt Another object to copy.
@@ -146,19 +145,18 @@ public:
 	 * Gets the user name to use for the connection.
 	 * @return The user name to use for the connection.
 	 */
-	const std::string& get_user_name() const { return userName_; }
+	string get_user_name() const { return userName_ ? userName_.to_string() : string(); }
 	/**
 	 * Gets the password to use for the connection.
 	 * @return The password to use for the connection.
 	 */
-	const byte_buffer& get_password() const { return password_; }
+	binary_ref get_password() const { return password_; }
 	/**
 	 * Gets the password to use for the connection.
 	 * @return The password to use for the connection.
 	 */
-	std::string get_password_str() const {
-		return std::string(reinterpret_cast<const char*>(password_.data()),
-						   password_.size());
+	string get_password_str() const {
+		return password_ ? password_.to_string() : string();
 	}
 	/**
 	 * Gets the maximum number of messages that can be in-flight
@@ -170,7 +168,7 @@ public:
 	 * Gets the topic to be used for last will and testament (LWT).
 	 * @return The topic to be used for last will and testament (LWT).
 	 */
-	std::string get_will_topic() const {
+	string get_will_topic() const {
 		return will_.get_topic();
 	}
 	/**
@@ -277,21 +275,14 @@ public:
 		set_connect_timeout((int) to_seconds(to).count());
 	}
 	/**
-	 * Sets the password to use for the connection.
-	 */
-	void set_password(const byte_buffer& password);
-	/**
-	 * Sets the password to use for the connection.
-	 */
-	void set_password(const std::string& password) {
-		set_password(byte_buffer(reinterpret_cast<const byte*>(password.data()),
-								 password.size()));
-	}
-	/**
 	 * Sets the user name to use for the connection.
 	 * @param userName
 	 */
-	void set_user_name(const std::string& userName);
+	void set_user_name(string_ref userName);
+	/**
+	 * Sets the password to use for the connection.
+	 */
+	void set_password(binary_ref password);
 	/**
 	 * Sets the maximum number of messages that can be in-flight
 	 * simultaneously.
@@ -321,7 +312,7 @@ public:
 	 * Gets a string representation of the object.
 	 * @return
 	 */
-	std::string to_str() const;
+	string to_str() const;
 };
 
 /** Smart/shared pointer to a connection options object. */

--- a/src/mqtt/delivery_token.h
+++ b/src/mqtt/delivery_token.h
@@ -99,21 +99,21 @@ public:
 	 * @param cli The asynchronous client object.
 	 * @param topic The topic that the message is associated with.
 	 */
-	delivery_token(iasync_client& cli, const std::string& topic) : token(cli, topic) {}
+	delivery_token(iasync_client& cli, const string& topic) : token(cli, topic) {}
 	/**
 	 * Creates a delivery token connected to a particular client.
 	 * @param cli The asynchronous client object.
 	 * @param topic The topic that the message is associated with.
 	 * @param msg The message data.
 	 */
-	delivery_token(iasync_client& cli, const std::string& topic, const_message_ptr msg)
+	delivery_token(iasync_client& cli, const string& topic, const_message_ptr msg)
 			: token(cli, topic), msg_(msg) {}
 	/**
 	 * Creates a delivery token connected to a particular client.
 	 * @param cli The asynchronous client object.
 	 * @param topics The topics that the message is associated with.
 	 */
-	delivery_token(iasync_client& cli, const std::vector<std::string>& topics)
+	delivery_token(iasync_client& cli, const std::vector<string>& topics)
 					: token(cli, topics) {}
 
 	/**
@@ -128,7 +128,7 @@ public:
 	 * @param cli The asynchronous client object.
 	 * @param topic The topic that the message is associated with.
 	 */
-	static ptr_t create(iasync_client& cli, const std::string& topic) {
+	static ptr_t create(iasync_client& cli, const string& topic) {
 		return std::make_shared<delivery_token>(cli, topic);
 	}
 	/**
@@ -137,7 +137,7 @@ public:
 	 * @param topic The topic that the message is associated with.
 	 * @param msg The message data.
 	 */
-	static ptr_t create(iasync_client& cli, const std::string& topic, const_message_ptr msg) {
+	static ptr_t create(iasync_client& cli, const string& topic, const_message_ptr msg) {
 		return std::make_shared<delivery_token>(cli, topic, msg);
 	}
 	/**
@@ -145,7 +145,7 @@ public:
 	 * @param cli The asynchronous client object.
 	 * @param topics The topics that the message is associated with.
 	 */
-	static ptr_t create(iasync_client& cli, const std::vector<std::string>& topics) {
+	static ptr_t create(iasync_client& cli, const std::vector<string>& topics) {
 		return std::make_shared<delivery_token>(cli, topics);
 	}
 	/**

--- a/src/mqtt/exception.h
+++ b/src/mqtt/exception.h
@@ -25,7 +25,7 @@
 #define __mqtt_exception_h
 
 #include "MQTTAsync.h"
-#include <string>
+#include "mqtt/types.h"
 #include <vector>
 #include <memory>
 #include <exception>
@@ -43,7 +43,7 @@ class exception : public std::runtime_error
 {
 	/** The error code from the C library */
 	int code_;
-	std::string msg_;
+	string msg_;
 
 public:
 	explicit exception(int reasonCode) : std::runtime_error("mqtt::exception"),
@@ -55,7 +55,7 @@ public:
 	/**
 	 * Returns the detail message for this exception.
 	 */
-	std::string get_message() const { return std::string(what()); }
+	string get_message() const { return string(what()); }
 	/**
 	 * Returns the reason code for this exception.
 	 */
@@ -64,7 +64,7 @@ public:
 	 * Gets a string representation of this exception.
 	 * @return A string representation of this exception.
 	 */
-	std::string to_str() const { return get_message(); }
+	string to_str() const { return get_message(); }
 	/**
 	 * Returns an explanatory string for the exception.
 	 * @return const char*

--- a/src/mqtt/iaction_listener.h
+++ b/src/mqtt/iaction_listener.h
@@ -25,9 +25,8 @@
 #define __mqtt_iaction_listener_h
 
 #include "MQTTAsync.h"
-#include <string>
+#include "mqtt/types.h"
 #include <vector>
-#include <memory>
 
 namespace mqtt {
 

--- a/src/mqtt/iasync_client.h
+++ b/src/mqtt/iasync_client.h
@@ -25,6 +25,7 @@
 #ifndef __mqtt_iasync_client_h
 #define __mqtt_iasync_client_h
 
+#include "mqtt/types.h"
 #include "mqtt/token.h"
 #include "mqtt/delivery_token.h"
 #include "mqtt/iclient_persistence.h"
@@ -34,7 +35,6 @@
 #include "mqtt/exception.h"
 #include "mqtt/message.h"
 #include "mqtt/callback.h"
-#include <string>
 #include <vector>
 
 namespace mqtt {
@@ -61,7 +61,7 @@ class iasync_client
 
 public:
 	/** Type for a collection of filters */
-	using topic_filter_collection = std::vector<std::string>;
+	using topic_filter_collection = std::vector<string>;
 	/** Type for a collection of QOS values */
 	using qos_collection = std::vector<int>;
 
@@ -176,13 +176,13 @@ public:
 	virtual std::vector<idelivery_token_ptr> get_pending_delivery_tokens() const =0;
 	/**
 	 * Returns the client ID used by this client.
-	 * @return std::string
+	 * @return string
 	 */
-	virtual std::string get_client_id() const =0;
+	virtual string get_client_id() const =0;
 	/**
 	 * Returns the address of the server used by this client.
 	 */
-	virtual std::string get_server_uri() const =0;
+	virtual string get_server_uri() const =0;
 	/**
 	 * Determines if this client is currently connected to the server.
 	 */
@@ -198,7 +198,7 @@ public:
 	 * @return token used to track and wait for the publish to complete. The
 	 *  	   token will be passed to callback methods if set.
 	 */
-	virtual idelivery_token_ptr publish(const std::string& topic, const void* payload,
+	virtual idelivery_token_ptr publish(const string& topic, const void* payload,
 										size_t n, int qos, bool retained) =0;
 	/**
 	 * Publishes a message to a topic on the server
@@ -214,7 +214,7 @@ public:
 	 * @return token used to track and wait for the publish to complete. The
 	 *  	   token will be passed to callback methods if set.
 	 */
-	virtual idelivery_token_ptr publish(const std::string& topic,
+	virtual idelivery_token_ptr publish(const string& topic,
 										const void* payload, size_t n,
 										int qos, bool retained, void* userContext,
 										iaction_listener& cb) =0;
@@ -227,7 +227,7 @@ public:
 	 * @return token used to track and wait for the publish to complete. The
 	 *  	   token will be passed to callback methods if set.
 	 */
-	virtual idelivery_token_ptr publish(const std::string& topic, const_message_ptr msg) =0;
+	virtual idelivery_token_ptr publish(const string& topic, const_message_ptr msg) =0;
 	/**
 	 * Publishes a message to a topic on the server.
 	 * @param topic the topic to deliver the message to
@@ -239,7 +239,7 @@ public:
 	 * @return token used to track and wait for the publish to complete. The
 	 *  	   token will be passed to callback methods if set.
 	 */
-	virtual idelivery_token_ptr publish(const std::string& topic, const_message_ptr msg,
+	virtual idelivery_token_ptr publish(const string& topic, const_message_ptr msg,
 										void* userContext, iaction_listener& cb) =0;
 	/**
 	 * Sets a callback listener to use for events that happen
@@ -295,7 +295,7 @@ public:
 	 * @return token used to track and wait for the subscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr subscribe(const std::string& topicFilter, int qos) =0;
+	virtual itoken_ptr subscribe(const string& topicFilter, int qos) =0;
 	/**
 	 * Subscribe to a topic, which may include wildcards.
 	 * @param topicFilter the topic to subscribe to, which can include
@@ -312,7 +312,7 @@ public:
 	 * @return token used to track and wait for the subscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr subscribe(const std::string& topicFilter, int qos,
+	virtual itoken_ptr subscribe(const string& topicFilter, int qos,
 								 void* userContext, iaction_listener& callback) =0;
 	/**
 	 * Requests the server unsubscribe the client from a topic.
@@ -321,7 +321,7 @@ public:
 	 * @return token used to track and wait for the unsubscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr unsubscribe(const std::string& topicFilter) =0;
+	virtual itoken_ptr unsubscribe(const string& topicFilter) =0;
 	/**
 	 * Requests the server unsubscribe the client from one or more topics.
 	 * @param topicFilters one or more topics to unsubscribe from. Each
@@ -356,7 +356,7 @@ public:
 	 * @return token used to track and wait for the unsubscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr unsubscribe(const std::string& topicFilter,
+	virtual itoken_ptr unsubscribe(const string& topicFilter,
 								   void* userContext, iaction_listener& cb) =0;
 };
 

--- a/src/mqtt/iclient_persistence.h
+++ b/src/mqtt/iclient_persistence.h
@@ -25,9 +25,8 @@
 #define __mqtt_iclient_persistence_h
 
 #include "MQTTAsync.h"
+#include "mqtt/types.h"
 #include "mqtt/ipersistable.h"
-#include <string>
-#include <memory>
 #include <vector>
 
 namespace mqtt {
@@ -80,7 +79,7 @@ public:
 	/**
 	 * Initialize the persistent store.
 	 */
-	virtual void open(const std::string& clientId, const std::string& serverURI) =0;
+	virtual void open(const string& clientId, const string& serverURI) =0;
 	/**
 	 * Close the persistent store that was previously opened.
 	 */
@@ -94,28 +93,28 @@ public:
 	 * @param key
 	 * @return bool
 	 */
-	virtual bool contains_key(const std::string& key) =0;
+	virtual bool contains_key(const string& key) =0;
 	/**
 	 * Gets the specified data out of the persistent store.
 	 * @param key
 	 * @return persistable
 	 */
-	virtual ipersistable_ptr get(const std::string& key) const =0;
+	virtual ipersistable_ptr get(const string& key) const =0;
 	/**
 	 * Returns an Enumeration over the keys in this persistent data store.
 	 */
-	virtual std::vector<std::string> keys() const =0;
+	virtual std::vector<string> keys() const =0;
 	/**
 	 * Puts the specified data into the persistent store.
 	 * @param key
 	 * @param persistable
 	 */
-	virtual void put(const std::string& key, ipersistable_ptr persistable) =0;
+	virtual void put(const string& key, ipersistable_ptr persistable) =0;
 	/**
 	 * Remove the data for the specified key.
 	 * @param key
 	 */
-	virtual void remove(const std::string& key) =0;
+	virtual void remove(const string& key) =0;
 };
 
 /** Smart/shared pointer to a persistence client */

--- a/src/mqtt/ipersistable.h
+++ b/src/mqtt/ipersistable.h
@@ -26,8 +26,6 @@
 
 #include "MQTTAsync.h"
 #include "mqtt/types.h"
-#include <string>
-#include <memory>
 #include <vector>
 #include <stdexcept>
 

--- a/src/mqtt/ssl_options.h
+++ b/src/mqtt/ssl_options.h
@@ -28,9 +28,8 @@
 #include "MQTTAsync.h"
 #include "mqtt/message.h"
 #include "mqtt/topic.h"
-#include <string>
+#include "mqtt/types.h"
 #include <vector>
-#include <memory>
 
 namespace mqtt {
 
@@ -48,22 +47,22 @@ class ssl_options
 	 * The file containing the public digital certificates trusted by
 	 * the client.
 	 */
-	std::string trustStore_;
+	string trustStore_;
 
 	/** The file containing the public certificate chain of the client. */
-	std::string keyStore_;
+	string keyStore_;
 
 	/** The file containing the client's private key. */
-	std::string privateKey_;
+	string privateKey_;
 
 	/** The password to load the client's privateKey if encrypted. */
-	std::string privateKeyPassword_;
+	string privateKeyPassword_;
 
 	/**
 	 * The list of cipher suites that the client will present to the
 	 * server during the SSL handshake.
 	 */
-	std::string enabledCipherSuites_;
+	string enabledCipherSuites_;
 
 	/** The connect options has special access */
 	friend class connect_options;
@@ -80,7 +79,7 @@ class ssl_options
 	 * @return Pointer to a NUL terminated string. This is only valid until
 	 *  	   the next time the string is updated.
 	 */
-	const char* c_str(const std::string& str) {
+	const char* c_str(const string& str) {
 		return str.empty() ? nullptr : str.c_str();
 	}
 	/**
@@ -113,11 +112,11 @@ public:
 	 * the server certificate
 	 */
 	ssl_options(
-			const std::string& trustStore,
-			const std::string& keyStore,
-			const std::string& privateKey,
-			const std::string& privateKeyPassword,
-			const std::string& enabledCipherSuites,
+			const string& trustStore,
+			const string& keyStore,
+			const string& privateKey,
+			const string& privateKeyPassword,
+			const string& enabledCipherSuites,
 			bool enableServerCertAuth);
 	/**
 	 * Copy constructor.
@@ -144,30 +143,30 @@ public:
 	/**
 	 * Returns the file containing the public digital certificates trusted by
 	 * the client.
-	 * @return std::string
+	 * @return string
 	 */
-	std::string get_trust_store() const { return trustStore_; }
+	string get_trust_store() const { return trustStore_; }
 	/**
 	 * Returns the file containing the public certificate chain of the client.
-	 * @return std::string
+	 * @return string
 	 */
-	std::string get_key_store() const { return keyStore_; }
+	string get_key_store() const { return keyStore_; }
 	/**
 	 * Returns the file containing the client's private key.
-	 * @return std::string
+	 * @return string
 	 */
-	std::string get_private_key() const { return privateKey_; }
+	string get_private_key() const { return privateKey_; }
 	/**
 	 * Returns the password to load the client's privateKey if encrypted.
-	 * @return std::string
+	 * @return string
 	 */
-	std::string get_private_key_password() const { return privateKeyPassword_; }
+	string get_private_key_password() const { return privateKeyPassword_; }
 	/**
 	 * Returns the list of cipher suites that the client will present to the
 	 * server during the SSL handshake.
-	 * @return std::string
+	 * @return string
 	 */
-	std::string get_enabled_cipher_suites() const { return enabledCipherSuites_; }
+	string get_enabled_cipher_suites() const { return enabledCipherSuites_; }
 	/**
 	 * Returns the true/false to enable verification of the server certificate .
 	 * @return bool
@@ -180,32 +179,32 @@ public:
 	 * the client.
 	 * @param trustStore
 	 */
-	void set_trust_store(const std::string& trustStore);
+	void set_trust_store(const string& trustStore);
 
 	/**
 	 * Sets the file containing the public certificate chain of the client.
 	 * @param keyStore
 	 */
-	void set_key_store(const std::string& keyStore);
+	void set_key_store(const string& keyStore);
 
 	/**
 	 * Sets the file containing the client's private key.
 	 * @param privateKey
 	 */
-	void set_private_key(const std::string& privateKey);
+	void set_private_key(const string& privateKey);
 
 	/**
 	 * Sets the password to load the client's privateKey if encrypted.
 	 * @param privateKeyPassword
 	 */
-	void set_private_key_password(const std::string& privateKeyPassword);
+	void set_private_key_password(const string& privateKeyPassword);
 
 	/**
 	 * Sets the list of cipher suites that the client will present to the server
 	 * during the SSL handshake.
 	 * @param enabledCipherSuites
 	 */
-	void set_enabled_cipher_suites(const std::string& enabledCipherSuites);
+	void set_enabled_cipher_suites(const string& enabledCipherSuites);
 
 	/**
 	 * Sets the if it's to enable verification of the server certificate.

--- a/src/mqtt/token.h
+++ b/src/mqtt/token.h
@@ -28,9 +28,7 @@
 #include "mqtt/iaction_listener.h"
 #include "mqtt/exception.h"
 #include "mqtt/types.h"
-#include <string>
 #include <vector>
-#include <memory>
 #include <thread>
 #include <mutex>
 #include <condition_variable>
@@ -79,9 +77,9 @@ public:
 	/**
 	 * Returns the topic string(s) for the action being tracked by this
 	 * token.
-	 * @return std::vector<std::string>
+	 * @return std::vector<string>
 	 */
-	virtual const std::vector<std::string>& get_topics() const =0;
+	virtual const std::vector<string>& get_topics() const =0;
 	/**
 	 * Retrieve the context associated with an action.
 	 * @return void*
@@ -149,7 +147,7 @@ class token : public virtual itoken
 	/** The underlying C token. Note that this is just an integer */
 	MQTTAsync_token tok_;
 	/** The topic string(s) for the action being tracked by this token */
-	std::vector<std::string> topics_;
+	std::vector<string> topics_;
 	/** User supplied context */
 	void* userContext_;
 	/**
@@ -172,11 +170,11 @@ class token : public virtual itoken
 	friend class delivery_response_options;
 	friend class disconnect_options;
 
-	void set_topics(const std::string& top) {
+	void set_topics(const string& top) {
 		topics_.clear();
 		topics_.push_back(top);
 	}
-	void set_topics(const std::vector<std::string>& top) {
+	void set_topics(const std::vector<string>& top) {
 		topics_ = top;
 	}
 
@@ -253,13 +251,13 @@ public:
 	 * @param cli The client that created the token.
 	 * @param topic The topic assiciated with the token
 	 */
-	token(iasync_client& cli, const std::string& topic);
+	token(iasync_client& cli, const string& topic);
 	/**
 	 * Constructs a token object.
 	 * @param cli The client that created the token.
 	 * @param topics The topics associated with the token
 	 */
-	token(iasync_client& cli, const std::vector<std::string>& topics);
+	token(iasync_client& cli, const std::vector<string>& topics);
 	/**
 	 * Constructs a token object.
 	 * @param cli The client that created the token.
@@ -284,7 +282,7 @@ public:
 	 * @param cli The client that created the token.
 	 * @param topic The topic assiciated with the token
 	 */
-	static ptr_t create(iasync_client& cli, const std::string& topic) {
+	static ptr_t create(iasync_client& cli, const string& topic) {
 		return std::make_shared<token>(cli, topic);
 	}
 	/**
@@ -292,7 +290,7 @@ public:
 	 * @param cli The client that created the token.
 	 * @param topics The topics associated with the token
 	 */
-	static ptr_t create(iasync_client& cli, const std::vector<std::string>& topics) {
+	static ptr_t create(iasync_client& cli, const std::vector<string>& topics) {
 		return std::make_shared<token>(cli, topics);
 	}
 	/**
@@ -322,7 +320,7 @@ public:
 	 * Returns the topic string(s) for the action being tracked by this
 	 * token.
 	 */
-	const std::vector<std::string>& get_topics() const override {
+	const std::vector<string>& get_topics() const override {
 		return topics_;
 	}
 	/**

--- a/src/mqtt/topic.h
+++ b/src/mqtt/topic.h
@@ -27,9 +27,8 @@
 #include "MQTTAsync.h"
 #include "mqtt/delivery_token.h"
 #include "mqtt/message.h"
-#include <string>
+#include "mqtt/types.h"
 #include <vector>
-#include <memory>
 
 namespace mqtt {
 
@@ -43,7 +42,7 @@ class async_client;
 class topic
 {
 	/** The topic name */
-	std::string name_;
+	string name_;
 
 	/** The client to which this topic is connected */
 	// TODO: Make this a smart pointer
@@ -59,12 +58,12 @@ public:
 	 * @param name
 	 * @param cli
 	 */
-	topic(const std::string& name, iasync_client& cli) : name_{name}, cli_{&cli} {}
+	topic(const string& name, iasync_client& cli) : name_{name}, cli_{&cli} {}
 	/**
 	 * Returns the name of the queue or topic.
-	 * @return std::string
+	 * @return string
 	 */
-	std::string get_name() const { return name_; }
+	string get_name() const { return name_; }
 	/**
 	 * Publishes a message on the topic.
 	 * @param payload
@@ -83,7 +82,7 @@ public:
 	 *
 	 * @return delivery_token
 	 */
-	idelivery_token_ptr publish(const std::string& payload, int qos, bool retained);
+	idelivery_token_ptr publish(const string& payload, int qos, bool retained);
 	/**
 	 * Publishes the specified message to this topic, but does not wait for
 	 * delivery of the message to complete.
@@ -93,9 +92,9 @@ public:
 	idelivery_token_ptr publish(const_message_ptr msg);
 	/**
 	 * Returns a string representation of this topic.
-	 * @return std::string
+	 * @return string
 	 */
-	std::string to_str() const { return name_; }
+	string to_str() const { return name_; }
 };
 
 /**

--- a/src/mqtt/types.h
+++ b/src/mqtt/types.h
@@ -24,6 +24,7 @@
 #define __mqtt_types_h
 
 #include <string>
+#include <memory>
 #include <chrono>
 
 namespace mqtt {
@@ -36,14 +37,20 @@ using byte = uint8_t;
 /** A collection of bytes  */
 using byte_buffer = std::basic_string<byte>;
 
+using string = std::string;
+using binary = std::basic_string<byte>;
+
+using string_ptr = std::shared_ptr<const string>;
+using binary_ptr = std::shared_ptr<const binary>;
+
 /**
  * Convert (cast) a byte_buffer to a string.
  * This creates a string that's a binary equivalent to the buffer.
  * @param buf A binary byte_buffer
  * @return A string that's a binary copy of the buffer.
  */
-inline std::string to_string(const byte_buffer& buf) {
-	return std::string(reinterpret_cast<const char*>(buf.data()), buf.size());
+inline string to_string(const byte_buffer& buf) {
+	return string(reinterpret_cast<const char*>(buf.data()), buf.size());
 }
 
 /**
@@ -52,17 +59,29 @@ inline std::string to_string(const byte_buffer& buf) {
  * @param str A string
  * @return A byte_buffer that's a binary copy of the string.
  */
-inline byte_buffer to_buffer(const std::string& str) {
+inline byte_buffer to_buffer(const string& str) {
 	return byte_buffer(reinterpret_cast<const byte*>(str.data()), str.size());
 }
 
 /////////////////////////////////////////////////////////////////////////////
 
+/**
+ * Convert a chrono duration to seconds.
+ * This casts away precision to get integer seconds.
+ * @param dur A chrono duration type
+ * @return The duration as a chrono seconds value
+ */
 template <class Rep, class Period>
 std::chrono::seconds to_seconds(const std::chrono::duration<Rep, Period>& dur) {
 	return std::chrono::duration_cast<std::chrono::seconds>(dur);
 }
 
+/**
+ * Convert a chrono duration to milliseconds.
+ * This casts away precision to get integer milliseconds.
+ * @param dur A chrono duration type
+ * @return The duration as a chrono milliseconds value
+ */
 template <class Rep, class Period>
 std::chrono::milliseconds to_milliseconds(const std::chrono::duration<Rep, Period>& dur) {
 	return std::chrono::duration_cast<std::chrono::milliseconds>(dur);

--- a/src/samples/async_publish.cpp
+++ b/src/samples/async_publish.cpp
@@ -25,8 +25,8 @@
 
 using namespace std;
 
-const string DFLT_ADDRESS {"tcp://localhost:1883"};
-const string DFLT_CLIENT_ID {"AsyncPublisher"};
+const std::string DFLT_ADDRESS {"tcp://localhost:1883"};
+const std::string DFLT_CLIENT_ID {"AsyncPublisher"};
 
 const string TOPIC {"hello"};
 

--- a/src/samples/async_subscribe.cpp
+++ b/src/samples/async_subscribe.cpp
@@ -33,6 +33,7 @@ const int  QOS = 1;
 
 class action_listener : public virtual mqtt::iaction_listener
 {
+
 	std::string name_;
 
 	void on_failure(const mqtt::itoken& tok) override {

--- a/src/samples/ssl_publish.cpp
+++ b/src/samples/ssl_publish.cpp
@@ -30,12 +30,10 @@
 #include <cstring>
 #include "mqtt/async_client.h"
 
-using namespace std;
+const std::string DFLT_ADDRESS {"ssl://localhost:18885"};
+const std::string DFLT_CLIENT_ID {"CppAsyncPublisherSSL"};
 
-const string DFLT_ADDRESS {"ssl://localhost:18885"};
-const string DFLT_CLIENT_ID {"CppAsyncPublisherSSL"};
-
-const string TOPIC {"hello"};
+const std::string TOPIC {"hello"};
 
 const char* PAYLOAD1 = "Hello World!";
 const char* PAYLOAD2 = "Hi there!";
@@ -53,22 +51,24 @@ const auto TIMEOUT = std::chrono::seconds(10);
 class callback : public virtual mqtt::callback
 {
 public:
-	void connection_lost(const string& cause) override {
-		cout << "\nConnection lost" << endl;
+	void connection_lost(const std::string& cause) override {
+		std::cout << "\nConnection lost" << std::endl;
 		if (!cause.empty())
-			cout << "\tcause: " << cause << endl;
+			std::cout << "\tcause: " << cause << std::endl;
 	}
 
 	// We're not subscribed to anything, so this should never be called.
-	void message_arrived(const string& topic, mqtt::const_message_ptr msg) override {}
+	void message_arrived(const std::string& topic, mqtt::const_message_ptr msg) override {}
 
 	void delivery_complete(mqtt::idelivery_token_ptr tok) override {
-		cout << "\tDelivery complete for token: "
-			<< (tok ? tok->get_message_id() : -1) << endl;
+		std::cout << "\tDelivery complete for token: "
+			<< (tok ? tok->get_message_id() : -1) << std::endl;
 	}
 };
 
 /////////////////////////////////////////////////////////////////////////////
+
+using namespace std;
 
 int main(int argc, char* argv[])
 {

--- a/src/samples/sync_publish.cpp
+++ b/src/samples/sync_publish.cpp
@@ -131,7 +131,7 @@ public:
 
 	// We're not subscrived to anything, so this should never be called.
 	void message_arrived(const std::string& topic,
-								 mqtt::const_message_ptr msg) override {}
+						 mqtt::const_message_ptr msg) override {}
 
 	void delivery_complete(mqtt::idelivery_token_ptr tok) override {
 		std::cout << "\n\t[Delivery complete for token: "

--- a/src/ssl_options.cpp
+++ b/src/ssl_options.cpp
@@ -28,11 +28,11 @@ ssl_options::ssl_options() : opts_(MQTTAsync_SSLOptions_initializer)
 }
 
 ssl_options::ssl_options(
-		const std::string& trustStore,
-		const std::string& keyStore,
-		const std::string& privateKey,
-		const std::string& privateKeyPassword,
-		const std::string& enabledCipherSuites,
+		const string& trustStore,
+		const string& keyStore,
+		const string& privateKey,
+		const string& privateKeyPassword,
+		const string& enabledCipherSuites,
 		bool enableServerCertAuth)
 		: opts_(MQTTAsync_SSLOptions_initializer),
 		  trustStore_(trustStore),
@@ -114,31 +114,31 @@ ssl_options& ssl_options::operator=(ssl_options&& rhs)
 	return *this;
 }
 
-void ssl_options::set_trust_store(const std::string& trustStore)
+void ssl_options::set_trust_store(const string& trustStore)
 {
 	trustStore_ = trustStore;
 	opts_.trustStore = c_str(trustStore_);
 }
 
-void ssl_options::set_key_store(const std::string& keyStore)
+void ssl_options::set_key_store(const string& keyStore)
 {
 	keyStore_ = keyStore;
 	opts_.keyStore = c_str(keyStore_);
 }
 
-void ssl_options::set_private_key(const std::string& privateKey)
+void ssl_options::set_private_key(const string& privateKey)
 {
 	privateKey_ = privateKey;
 	opts_.privateKey = c_str(privateKey_);
 }
 
-void ssl_options::set_private_key_password(const std::string& privateKeyPassword)
+void ssl_options::set_private_key_password(const string& privateKeyPassword)
 {
 	privateKeyPassword_ = privateKeyPassword;
 	opts_.privateKeyPassword = c_str(privateKeyPassword_);
 }
 
-void ssl_options::set_enabled_cipher_suites(const std::string& enabledCipherSuites)
+void ssl_options::set_enabled_cipher_suites(const string& enabledCipherSuites)
 {
 	enabledCipherSuites_ = enabledCipherSuites;
 	opts_.enabledCipherSuites = c_str(enabledCipherSuites_);

--- a/src/token.cpp
+++ b/src/token.cpp
@@ -18,7 +18,6 @@
 
 #include "mqtt/token.h"
 #include "mqtt/async_client.h"
-#include <string>
 #include <cstring>
 
 namespace mqtt {
@@ -103,13 +102,13 @@ token::token(iasync_client& cli, MQTTAsync_token tok)
 {
 }
 
-token::token(iasync_client& cli, const std::string& top)
+token::token(iasync_client& cli, const string& top)
 				: token(cli, MQTTAsync_token(0))
 {
 	topics_.push_back(top);
 }
 
-token::token(iasync_client& cli, const std::vector<std::string>& topics)
+token::token(iasync_client& cli, const std::vector<string>& topics)
 				: cli_(&cli), tok_(MQTTAsync_token(0)), topics_(topics),
 						userContext_(nullptr), listener_(nullptr),
 						complete_(false), rc_(0)

--- a/src/topic.cpp
+++ b/src/topic.cpp
@@ -30,7 +30,7 @@ idelivery_token_ptr topic::publish(const void* payload, size_t n,
 	return cli_->publish(name_, payload, n, qos, retained);
 }
 
-idelivery_token_ptr topic::publish(const std::string& payload, int qos, bool retained)
+idelivery_token_ptr topic::publish(const string& payload, int qos, bool retained)
 {
 	return publish(payload.data(), payload.length(), qos, retained);
 }

--- a/test/unit/connect_options_test.h
+++ b/test/unit/connect_options_test.h
@@ -287,7 +287,7 @@ public:
 
 	void test_set_long_user() {
 		std::string user;
-		byte_buffer passwd;
+		std::string passwd;
 		for (int i=0; i<1053; ++i) {
 			if (isprint(char(i))) user.push_back(char(i));
 			passwd.push_back(byte(i));
@@ -299,13 +299,13 @@ public:
 		orgOpts.set_password(passwd);
 
 		CPPUNIT_ASSERT_EQUAL(user, orgOpts.get_user_name());
-		CPPUNIT_ASSERT(passwd == orgOpts.get_password());
+		CPPUNIT_ASSERT(passwd == orgOpts.get_password_str());
 
 		mqtt::connect_options opts;
 		opts = orgOpts;
 
 		CPPUNIT_ASSERT_EQUAL(user, opts.get_user_name());
-		CPPUNIT_ASSERT(passwd == opts.get_password());
+		CPPUNIT_ASSERT(passwd == opts.get_password_str());
 
 		const auto& c_struct = opts.opts_;
 

--- a/test/unit/will_options_test.h
+++ b/test/unit/will_options_test.h
@@ -20,13 +20,10 @@
 #ifndef __mqtt_will_options_test_h
 #define __mqtt_will_options_test_h
 
+#include "mqtt/will_options.h"
+#include "dummy_async_client.h"
 #include <cppunit/ui/text/TestRunner.h>
 #include <cppunit/extensions/HelperMacros.h>
-
-#include "mqtt/will_options.h"
-
-#include "dummy_async_client.h"
-
 #include <cstring>
 
 namespace mqtt {
@@ -96,7 +93,8 @@ public:
 		const auto& c_struct = opts.opts_;
 
 		CPPUNIT_ASSERT(!memcmp(&c_struct.struct_id, CSIG, CSIG_LEN));
-		CPPUNIT_ASSERT(c_struct.topicName == nullptr);
+		CPPUNIT_ASSERT(c_struct.topicName != nullptr);
+		CPPUNIT_ASSERT_EQUAL(size_t(0), strlen(c_struct.topicName));
 		CPPUNIT_ASSERT(c_struct.message == nullptr);
 		CPPUNIT_ASSERT_EQUAL(0, c_struct.payload.len);
 		CPPUNIT_ASSERT(c_struct.payload.data == nullptr);
@@ -252,12 +250,6 @@ public:
 		// Check that the original was moved
 		CPPUNIT_ASSERT_EQUAL(EMPTY_STR, orgOpts.get_topic());
 		CPPUNIT_ASSERT_EQUAL(EMPTY_STR, orgOpts.get_payload_str());
-		CPPUNIT_ASSERT_EQUAL(DFLT_QOS, orgOpts.get_qos());
-		CPPUNIT_ASSERT_EQUAL(DFLT_RETAINED, orgOpts.is_retained());
-
-		CPPUNIT_ASSERT(orgOpts.opts_.topicName == nullptr);
-		CPPUNIT_ASSERT_EQUAL(0, orgOpts.opts_.payload.len);
-		CPPUNIT_ASSERT(orgOpts.opts_.payload.data == nullptr);
 	}
 
 // ----------------------------------------------------------------------
@@ -329,12 +321,6 @@ public:
 		// Check that the original was moved
 		CPPUNIT_ASSERT_EQUAL(EMPTY_STR, orgOpts.get_topic());
 		CPPUNIT_ASSERT_EQUAL(EMPTY_STR, orgOpts.get_payload_str());
-		CPPUNIT_ASSERT_EQUAL(DFLT_QOS, orgOpts.get_qos());
-		CPPUNIT_ASSERT_EQUAL(DFLT_RETAINED, orgOpts.is_retained());
-
-		CPPUNIT_ASSERT(orgOpts.opts_.topicName == nullptr);
-		CPPUNIT_ASSERT_EQUAL(0, orgOpts.opts_.payload.len);
-		CPPUNIT_ASSERT(orgOpts.opts_.payload.data == nullptr);
 
 		// Self assignment should cause no harm
 		// (clang++ is smart enough to warn about this)


### PR DESCRIPTION
Created a buffer reference template class, 'buffer_ref' and modified the various buffers (payloads, username, password, etc) to use it via aliases 'string_ref' and 'binary_ref'.

Since the buffers provided to the library by the application are never modified by the library, it seems that we might achieve greater performance if we create a single, immutable copy of the buffer and pass around references to it. Since the buffer is guaranteed to, remain constant, we have no issues of thread safety.

The reference class uses a shared pointer to a const buffer internally. The shared pointer ensure the lifetime of the buffer for as long as it's needed by the library/application, and cleans up properly with no memory leaks.

This would make copy semantics for `mqtt::message`, `mqtt::connect_options`, and the other options, relative fast and independent of the size of the payloads. In cases where the object might be updated by the library, such as changing the message ID, the library could copy the object easily and pass it along, rather than locking and mutating the object itself.

See #60 