### PR TITLE
Implementation of issue #83, remove the token interfaces

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -87,7 +87,7 @@ std::string client::get_server_uri() const
 //Debug 	getDebug()
 //Return a debug object that can be used to help solve problems.
 
-std::vector<idelivery_token_ptr> client::get_pending_delivery_tokens() const
+std::vector<delivery_token_ptr> client::get_pending_delivery_tokens() const
 {
 	return cli_.get_pending_delivery_tokens();
 }

--- a/src/mqtt/async_client.h
+++ b/src/mqtt/async_client.h
@@ -76,9 +76,9 @@ private:
 	/** Callback supplied by the user (if any) */
 	callback* userCallback_;
 	/** A list of tokens that are in play */
-	std::list<itoken_ptr> pendingTokens_;
+	std::list<token_ptr> pendingTokens_;
 	/** A list of delivery tokens that are in play */
-	std::list<idelivery_token_ptr> pendingDeliveryTokens_;
+	std::list<delivery_token_ptr> pendingDeliveryTokens_;
 
 	static void on_connection_lost(void *context, char *cause);
 	static int on_message_arrived(void* context, char* topicName, int topicLen,
@@ -87,11 +87,11 @@ private:
 
 	/** Manage internal list of active tokens */
 	friend class token;
-	virtual void add_token(itoken_ptr tok);
-	virtual void add_token(idelivery_token_ptr tok);
-	virtual void remove_token(itoken* tok) override;
-	virtual void remove_token(itoken_ptr tok) { remove_token(tok.get()); }
-	void remove_token(idelivery_token_ptr tok) { remove_token(tok.get()); }
+	virtual void add_token(token_ptr tok);
+	virtual void add_token(delivery_token_ptr tok);
+	virtual void remove_token(token* tok) override;
+	virtual void remove_token(token_ptr tok) { remove_token(tok.get()); }
+	void remove_token(delivery_token_ptr tok) { remove_token(tok.get()); }
 
 	/** Memory management for C-style filter collections */
 	std::vector<char*> alloc_topic_filters(
@@ -160,7 +160,7 @@ public:
 	 * @throw exception for non security related problems
 	 * @throw security_exception for security related problems
 	 */
-	itoken_ptr connect() override;
+	token_ptr connect() override;
 	/**
 	 * Connects to an MQTT server using the provided connect options.
 	 * @param options a set of connection parameters that override the
@@ -170,7 +170,7 @@ public:
 	 * @throw exception for non security related problems
 	 * @throw security_exception for security related problems
 	 */
-	itoken_ptr connect(connect_options options) override;
+	token_ptr connect(connect_options options) override;
 	/**
 	 * Connects to an MQTT server using the specified options.
 	 * @param options a set of connection parameters that override the
@@ -184,7 +184,7 @@ public:
 	 * @throw exception for non security related problems
 	 * @throw security_exception for security related problems
 	 */
-	itoken_ptr connect(connect_options options, void* userContext,
+	token_ptr connect(connect_options options, void* userContext,
 					   iaction_listener& cb) override;
 	/**
 	 *
@@ -197,14 +197,14 @@ public:
 	 * @throw exception for non security related problems
 	 * @throw security_exception for security related problems
 	 */
-	itoken_ptr connect(void* userContext, iaction_listener& cb) override;
+	token_ptr connect(void* userContext, iaction_listener& cb) override;
 	/**
 	 * Disconnects from the server.
 	 * @return token used to track and wait for the disconnect to complete.
 	 *  	   The token will be passed to any callback that has been set.
 	 * @throw exception for problems encountered while disconnecting
 	 */
-	itoken_ptr disconnect() override { return disconnect(disconnect_options()); }
+	token_ptr disconnect() override { return disconnect(disconnect_options()); }
 	/**
 	 * Disconnects from the server.
 	 * @param opts Options for disconnecting.
@@ -212,7 +212,7 @@ public:
 	 *  	   The token will be passed to any callback that has been set.
 	 * @throw exception for problems encountered while disconnecting
 	 */
-	itoken_ptr disconnect(disconnect_options opts) override;
+	token_ptr disconnect(disconnect_options opts) override;
 	/**
 	 * Disconnects from the server.
 	 * @param timeout the amount of time in milliseconds to allow for
@@ -223,7 +223,7 @@ public:
 	 *  	   set.
 	 * @throw exception for problems encountered while disconnecting
 	 */
-	itoken_ptr disconnect(int timeout) override;
+	token_ptr disconnect(int timeout) override;
 	/**
 	 * Disconnects from the server.
 	 * @param timeout the amount of time in milliseconds to allow for
@@ -235,7 +235,7 @@ public:
 	 * @throw exception for problems encountered while disconnecting
 	 */
 	template <class Rep, class Period>
-	itoken_ptr disconnect(const std::chrono::duration<Rep, Period>& timeout) {
+	token_ptr disconnect(const std::chrono::duration<Rep, Period>& timeout) {
 		// TODO: check range
 		return disconnect((int) to_milliseconds(timeout).count());
 	}
@@ -248,12 +248,12 @@ public:
 	 *  				  callback. Use @em nullptr if not required.
 	 * @param cb callback listener that will be notified when the disconnect
 	 *  			   completes.
-	 * @return itoken_ptr Token used to track and wait for disconnect to
+	 * @return token_ptr Token used to track and wait for disconnect to
 	 *  	   complete. The token will be passed to the callback methods if
 	 *  	   a callback is set.
 	 * @throw exception for problems encountered while disconnecting
 	 */
-	itoken_ptr disconnect(int timeout, void* userContext,
+	token_ptr disconnect(int timeout, void* userContext,
 						  iaction_listener& cb) override;
 	/**
 	 * Disconnects from the server.
@@ -264,13 +264,13 @@ public:
 	 *  				  callback. Use @em nullptr if not required.
 	 * @param cb callback listener that will be notified when the disconnect
 	 *  			   completes.
-	 * @return itoken_ptr Token used to track and wait for disconnect to
+	 * @return token_ptr Token used to track and wait for disconnect to
 	 *  	   complete. The token will be passed to the callback methods if
 	 *  	   a callback is set.
 	 * @throw exception for problems encountered while disconnecting
 	 */
 	template <class Rep, class Period>
-	itoken_ptr disconnect(const std::chrono::duration<Rep, Period>& timeout,
+	token_ptr disconnect(const std::chrono::duration<Rep, Period>& timeout,
 						  void* userContext, iaction_listener& cb) {
 		// TODO: check range
 		return disconnect((int) to_milliseconds(timeout).count(), userContext, cb);
@@ -281,24 +281,24 @@ public:
 	 *  				  callback. Use @em nullptr if not required.
 	 * @param cb callback listener that will be notified when the disconnect
 	 *  			   completes.
-	 * @return itoken_ptr Token used to track and wait for disconnect to
+	 * @return token_ptr Token used to track and wait for disconnect to
 	 *  	   complete. The token will be passed to the callback methods if
 	 *  	   a callback is set.
 	 * @throw exception for problems encountered while disconnecting
 	 */
-	itoken_ptr disconnect(void* userContext, iaction_listener& cb) override {
+	token_ptr disconnect(void* userContext, iaction_listener& cb) override {
 		return disconnect(0L, userContext, cb);
 	}
 	/**
 	 * Returns the delivery token for the specified message ID.
-	 * @return idelivery_token
+	 * @return delivery_token
 	 */
-	idelivery_token_ptr get_pending_delivery_token(int msgID) const override;
+	delivery_token_ptr get_pending_delivery_token(int msgID) const override;
 	/**
 	 * Returns the delivery tokens for any outstanding publish operations.
-	 * @return idelivery_token[]
+	 * @return delivery_token[]
 	 */
-	std::vector<idelivery_token_ptr> get_pending_delivery_tokens() const override;
+	std::vector<delivery_token_ptr> get_pending_delivery_tokens() const override;
 	/**
 	 * Returns the client ID used by this client.
 	 * @return The client ID used by this client.
@@ -326,7 +326,7 @@ public:
 	 * @return token used to track and wait for the publish to complete. The
 	 *  	   token will be passed to callback methods if set.
 	 */
-	idelivery_token_ptr publish(const std::string& topic, const void* payload,
+	delivery_token_ptr publish(const std::string& topic, const void* payload,
 								size_t n, int qos, bool retained) override;
 	/**
 	 * Publishes a message to a topic on the server
@@ -343,7 +343,7 @@ public:
 	 * @return token used to track and wait for the publish to complete. The
 	 *  	   token will be passed to callback methods if set.
 	 */
-	idelivery_token_ptr publish(const std::string& topic,
+	delivery_token_ptr publish(const std::string& topic,
 								const void* payload, size_t n,
 								int qos, bool retained, void* userContext,
 								iaction_listener& cb) override;
@@ -356,7 +356,7 @@ public:
 	 * @return token used to track and wait for the publish to complete. The
 	 *  	   token will be passed to callback methods if set.
 	 */
-	idelivery_token_ptr publish(const std::string& topic, const_message_ptr msg) override;
+	delivery_token_ptr publish(const std::string& topic, const_message_ptr msg) override;
 	/**
 	 * Publishes a message to a topic on the server.
 	 * @param topic the topic to deliver the message to
@@ -369,7 +369,7 @@ public:
 	 * @return token used to track and wait for the publish to complete. The
 	 *  	   token will be passed to callback methods if set.
 	 */
-	idelivery_token_ptr publish(const std::string& topic, const_message_ptr msg,
+	delivery_token_ptr publish(const std::string& topic, const_message_ptr msg,
 								void* userContext, iaction_listener& cb) override;
 	/**
 	 * Sets a callback listener to use for events that happen
@@ -388,7 +388,7 @@ public:
 	 * @return token used to track and wait for the subscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	itoken_ptr subscribe(const topic_filter_collection& topicFilters,
+	token_ptr subscribe(const topic_filter_collection& topicFilters,
 						 const qos_collection& qos) override;
 	/**
 	 * Subscribes to multiple topics, each of which may include wildcards.
@@ -404,7 +404,7 @@ public:
 	 * @return token used to track and wait for the subscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	itoken_ptr subscribe(const topic_filter_collection& topicFilters,
+	token_ptr subscribe(const topic_filter_collection& topicFilters,
 						 const qos_collection& qos,
 						 void* userContext, iaction_listener& cb) override;
 	/**
@@ -416,7 +416,7 @@ public:
 	 * @return token used to track and wait for the subscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	itoken_ptr subscribe(const std::string& topicFilter, int qos) override;
+	token_ptr subscribe(const std::string& topicFilter, int qos) override;
 	/**
 	 * Subscribe to a topic, which may include wildcards.
 	 * @param topicFilter the topic to subscribe to, which can include
@@ -432,7 +432,7 @@ public:
 	 * @return token used to track and wait for the subscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	itoken_ptr subscribe(const std::string& topicFilter, int qos,
+	token_ptr subscribe(const std::string& topicFilter, int qos,
 						 void* userContext, iaction_listener& cb) override;
 	/**
 	 * Requests the server unsubscribe the client from a topic.
@@ -441,7 +441,7 @@ public:
 	 * @return token used to track and wait for the unsubscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	itoken_ptr unsubscribe(const std::string& topicFilter) override;
+	token_ptr unsubscribe(const std::string& topicFilter) override;
 	/**
 	 * Requests the server unsubscribe the client from one or more topics.
 	 * @param topicFilters one or more topics to unsubscribe from. Each
@@ -450,7 +450,7 @@ public:
 	 * @return token used to track and wait for the unsubscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	itoken_ptr unsubscribe(const topic_filter_collection& topicFilters) override;
+	token_ptr unsubscribe(const topic_filter_collection& topicFilters) override;
 	/**
 	 * Requests the server unsubscribe the client from one or more topics.
 	 * @param topicFilters
@@ -461,7 +461,7 @@ public:
 	 * @return token used to track and wait for the unsubscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	itoken_ptr unsubscribe(const topic_filter_collection& topicFilters,
+	token_ptr unsubscribe(const topic_filter_collection& topicFilters,
 						   void* userContext, iaction_listener& cb) override;
 	/**
 	 * Requests the server unsubscribe the client from a topics.
@@ -474,7 +474,7 @@ public:
 	 * @return token used to track and wait for the unsubscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	itoken_ptr unsubscribe(const std::string& topicFilter,
+	token_ptr unsubscribe(const std::string& topicFilter,
 						   void* userContext, iaction_listener& cb) override;
 };
 

--- a/src/mqtt/callback.h
+++ b/src/mqtt/callback.h
@@ -66,7 +66,7 @@ public:
 	 * acknowledgments have been received.
 	 * @param tok The token tracking the message delivery.
 	 */
-	virtual void delivery_complete(idelivery_token_ptr tok) =0;
+	virtual void delivery_complete(delivery_token_ptr tok) =0;
 };
 
 /** Smart/shared pointer to a callback object */

--- a/src/mqtt/client.h
+++ b/src/mqtt/client.h
@@ -131,7 +131,7 @@ public:
 	/**
 	 * Returns the delivery tokens for any outstanding publish operations.
 	 */
-	virtual std::vector<idelivery_token_ptr> get_pending_delivery_tokens() const;
+	virtual std::vector<delivery_token_ptr> get_pending_delivery_tokens() const;
 	/**
 	 * Returns the address of the server used by this client, as a URI.
 	 * @return std::string

--- a/src/mqtt/delivery_token.h
+++ b/src/mqtt/delivery_token.h
@@ -34,40 +34,11 @@ namespace mqtt {
 /////////////////////////////////////////////////////////////////////////////
 
 /**
- * Provides a mechanism for tracking the delivery of a message.
- */
-class idelivery_token : public virtual itoken
-{
-public:
-	/** Smart/shared pointer to an object of this class */
-	using ptr_t = std::shared_ptr<idelivery_token>;
-	/** Smart/shared pointer to a const object of this class */
-	using const_ptr_t = std::shared_ptr<const idelivery_token>;
-	/** Weak pointer to an object of this class */
-	using weak_ptr_t = std::weak_ptr<idelivery_token>;
-
-	/**
-	 * Gets the message associated with this token.
-	 * @return The message associated with this token.
-	 */
-	virtual const_message_ptr get_message() const =0;
-};
-
-/** Smart/shared pointer to a delivery token */
-using idelivery_token_ptr = idelivery_token::ptr_t;
-
-/** Smart/shared pointer to a const delivery token */
-using const_idelivery_token_ptr = idelivery_token::const_ptr_t;
-
-/////////////////////////////////////////////////////////////////////////////
-
-/**
  * Provides a mechanism to track the delivery progress of a message.
  * Used to track the the delivery progress of a message when a publish is
  * executed in a non-blocking manner (run in the background) action.
  */
-class delivery_token : public virtual idelivery_token,
-						public token
+class delivery_token : public token
 {
 	/** The message being tracked. */
 	const_message_ptr msg_;
@@ -152,7 +123,7 @@ public:
 	 * Gets the message associated with this token.
 	 * @return The message associated with this token.
 	 */
-	const_message_ptr get_message() const override { return msg_; }
+	virtual const_message_ptr get_message() const { return msg_; }
 };
 
 /** Smart/shared pointer to a delivery_token */

--- a/src/mqtt/iaction_listener.h
+++ b/src/mqtt/iaction_listener.h
@@ -31,7 +31,7 @@
 
 namespace mqtt {
 
-class itoken;
+class token;
 
 /////////////////////////////////////////////////////////////////////////////
 
@@ -62,12 +62,12 @@ public:
 	 * This method is invoked when an action fails.
 	 * @param asyncActionToken
 	 */
-	virtual void on_failure(const itoken& asyncActionToken) =0;
+	virtual void on_failure(const token& asyncActionToken) =0;
 	/**
 	 * This method is invoked when an action has completed successfully.
 	 * @param asyncActionToken
 	 */
-	virtual void on_success(const itoken& asyncActionToken) =0;
+	virtual void on_success(const token& asyncActionToken) =0;
 };
 
 /** Smart/shared pointer to an action listener */

--- a/src/mqtt/iasync_client.h
+++ b/src/mqtt/iasync_client.h
@@ -57,7 +57,7 @@ namespace mqtt {
 class iasync_client
 {
 	friend class token;
-	virtual void remove_token(itoken* tok) =0;
+	virtual void remove_token(token* tok) =0;
 
 public:
 	/** Type for a collection of filters */
@@ -76,7 +76,7 @@ public:
 	 * @throw exception for non security related problems
 	 * @throw security_exception for security related problems
 	 */
-	virtual itoken_ptr connect() =0;
+	virtual token_ptr connect() =0;
 	/**
 	 * Connects to an MQTT server using the provided connect options.
 	 * @param options a set of connection parameters that override the
@@ -86,7 +86,7 @@ public:
 	 * @throw exception for non security related problems
 	 * @throw security_exception for security related problems
 	 */
-	virtual itoken_ptr connect(connect_options options) =0;
+	virtual token_ptr connect(connect_options options) =0;
 	/**
 	 * Connects to an MQTT server using the specified options.
 	 *
@@ -101,7 +101,7 @@ public:
 	 * @throw exception for non security related problems
 	 * @throw security_exception for security related problems
 	 */
-	virtual itoken_ptr connect(connect_options options, void* userContext,
+	virtual token_ptr connect(connect_options options, void* userContext,
 							   iaction_listener& cb) =0;
 	/**
 	 *
@@ -113,14 +113,14 @@ public:
 	 * @throw exception for non security related problems
 	 * @throw security_exception for security related problems
 	 */
-	virtual itoken_ptr connect(void* userContext, iaction_listener& cb) =0;
+	virtual token_ptr connect(void* userContext, iaction_listener& cb) =0;
 	/**
 	 * Disconnects from the server.
 	 * @return token used to track and wait for the disconnect to complete.
 	 *  	   The token will be passed to any callback that has been set.
 	 * @throw exception for problems encountered while disconnecting
 	 */
-	virtual itoken_ptr disconnect() =0;
+	virtual token_ptr disconnect() =0;
 	/**
 	 * Disconnects from the server.
 	 * @param opts Options for disconnecting.
@@ -128,7 +128,7 @@ public:
 	 *  	   The token will be passed to any callback that has been set.
 	 * @throw exception for problems encountered while disconnecting
 	 */
-	virtual itoken_ptr disconnect(disconnect_options opts) =0;
+	virtual token_ptr disconnect(disconnect_options opts) =0;
 	/**
 	 * Disconnects from the server.
 	 * @param timeout the amount of time in milliseconds to allow for
@@ -138,7 +138,7 @@ public:
 	 *  	   The token will be passed to any callback that has been set.
 	 * @throw exception for problems encountered while disconnecting
 	 */
-	virtual itoken_ptr disconnect(int timeout) =0;
+	virtual token_ptr disconnect(int timeout) =0;
 	/**
 	 * Disconnects from the server.
 	 * @param timeout the amount of time in milliseconds to allow for
@@ -152,7 +152,7 @@ public:
 	 *  	   The token will be passed to any callback that has been set.
 	 * @throw exception for problems encountered while disconnecting
 	 */
-	virtual itoken_ptr disconnect(int timeout, void* userContext, iaction_listener& cb) =0;
+	virtual token_ptr disconnect(int timeout, void* userContext, iaction_listener& cb) =0;
 	/**
 	 * Disconnects from the server.
 	 * @param userContext optional object used to pass context to the
@@ -163,17 +163,17 @@ public:
 	 *  	   The token will be passed to any callback that has been set.
 	 * @throw exception for problems encountered while disconnecting
 	 */
-	virtual itoken_ptr disconnect(void* userContext, iaction_listener& cb) =0;
+	virtual token_ptr disconnect(void* userContext, iaction_listener& cb) =0;
 	/**
 	 * Returns the delivery token for the specified message ID.
-	 * @return idelivery_token
+	 * @return delivery_token
 	 */
-	virtual idelivery_token_ptr get_pending_delivery_token(int msgID) const =0;
+	virtual delivery_token_ptr get_pending_delivery_token(int msgID) const =0;
 	/**
 	 * Returns the delivery tokens for any outstanding publish operations.
-	 * @return idelivery_token[]
+	 * @return delivery_token[]
 	 */
-	virtual std::vector<idelivery_token_ptr> get_pending_delivery_tokens() const =0;
+	virtual std::vector<delivery_token_ptr> get_pending_delivery_tokens() const =0;
 	/**
 	 * Returns the client ID used by this client.
 	 * @return std::string
@@ -198,7 +198,7 @@ public:
 	 * @return token used to track and wait for the publish to complete. The
 	 *  	   token will be passed to callback methods if set.
 	 */
-	virtual idelivery_token_ptr publish(const std::string& topic, const void* payload,
+	virtual delivery_token_ptr publish(const std::string& topic, const void* payload,
 										size_t n, int qos, bool retained) =0;
 	/**
 	 * Publishes a message to a topic on the server
@@ -214,7 +214,7 @@ public:
 	 * @return token used to track and wait for the publish to complete. The
 	 *  	   token will be passed to callback methods if set.
 	 */
-	virtual idelivery_token_ptr publish(const std::string& topic,
+	virtual delivery_token_ptr publish(const std::string& topic,
 										const void* payload, size_t n,
 										int qos, bool retained, void* userContext,
 										iaction_listener& cb) =0;
@@ -227,7 +227,7 @@ public:
 	 * @return token used to track and wait for the publish to complete. The
 	 *  	   token will be passed to callback methods if set.
 	 */
-	virtual idelivery_token_ptr publish(const std::string& topic, const_message_ptr msg) =0;
+	virtual delivery_token_ptr publish(const std::string& topic, const_message_ptr msg) =0;
 	/**
 	 * Publishes a message to a topic on the server.
 	 * @param topic the topic to deliver the message to
@@ -239,7 +239,7 @@ public:
 	 * @return token used to track and wait for the publish to complete. The
 	 *  	   token will be passed to callback methods if set.
 	 */
-	virtual idelivery_token_ptr publish(const std::string& topic, const_message_ptr msg,
+	virtual delivery_token_ptr publish(const std::string& topic, const_message_ptr msg,
 										void* userContext, iaction_listener& cb) =0;
 	/**
 	 * Sets a callback listener to use for events that happen
@@ -262,7 +262,7 @@ public:
 	 * @return token used to track and wait for the subscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr subscribe(const topic_filter_collection& topicFilters,
+	virtual token_ptr subscribe(const topic_filter_collection& topicFilters,
 								 const qos_collection& qos) =0;
 	/**
 	 * Subscribes to multiple topics, each of which may include wildcards.
@@ -280,7 +280,7 @@ public:
 	 * @return token used to track and wait for the subscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr subscribe(const topic_filter_collection& topicFilters,
+	virtual token_ptr subscribe(const topic_filter_collection& topicFilters,
 								 const qos_collection& qos,
 								 void* userContext, iaction_listener& callback) =0;
 	/**
@@ -295,7 +295,7 @@ public:
 	 * @return token used to track and wait for the subscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr subscribe(const std::string& topicFilter, int qos) =0;
+	virtual token_ptr subscribe(const std::string& topicFilter, int qos) =0;
 	/**
 	 * Subscribe to a topic, which may include wildcards.
 	 * @param topicFilter the topic to subscribe to, which can include
@@ -312,7 +312,7 @@ public:
 	 * @return token used to track and wait for the subscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr subscribe(const std::string& topicFilter, int qos,
+	virtual token_ptr subscribe(const std::string& topicFilter, int qos,
 								 void* userContext, iaction_listener& callback) =0;
 	/**
 	 * Requests the server unsubscribe the client from a topic.
@@ -321,7 +321,7 @@ public:
 	 * @return token used to track and wait for the unsubscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr unsubscribe(const std::string& topicFilter) =0;
+	virtual token_ptr unsubscribe(const std::string& topicFilter) =0;
 	/**
 	 * Requests the server unsubscribe the client from one or more topics.
 	 * @param topicFilters one or more topics to unsubscribe from. Each
@@ -330,7 +330,7 @@ public:
 	 * @return token used to track and wait for the unsubscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr unsubscribe(const topic_filter_collection& topicFilters) =0;
+	virtual token_ptr unsubscribe(const topic_filter_collection& topicFilters) =0;
 	/**
 	 * Requests the server unsubscribe the client from one or more topics.
 	 * @param topicFilters one or more topics to unsubscribe from. Each
@@ -343,7 +343,7 @@ public:
 	 * @return token used to track and wait for the unsubscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr unsubscribe(const topic_filter_collection& topicFilters,
+	virtual token_ptr unsubscribe(const topic_filter_collection& topicFilters,
 								   void* userContext, iaction_listener& cb) =0;
 	/**
 	 * Requests the server unsubscribe the client from a topics.
@@ -356,7 +356,7 @@ public:
 	 * @return token used to track and wait for the unsubscribe to complete.
 	 *  	   The token will be passed to callback methods if set.
 	 */
-	virtual itoken_ptr unsubscribe(const std::string& topicFilter,
+	virtual token_ptr unsubscribe(const std::string& topicFilter,
 								   void* userContext, iaction_listener& cb) =0;
 };
 

--- a/src/mqtt/topic.h
+++ b/src/mqtt/topic.h
@@ -74,7 +74,7 @@ public:
 	 *
 	 * @return delivery_token
 	 */
-	idelivery_token_ptr publish(const void* payload, size_t n, int qos, bool retained);
+	delivery_token_ptr publish(const void* payload, size_t n, int qos, bool retained);
 	/**
 	 * Publishes a message on the topic.
 	 * @param payload
@@ -83,14 +83,14 @@ public:
 	 *
 	 * @return delivery_token
 	 */
-	idelivery_token_ptr publish(const std::string& payload, int qos, bool retained);
+	delivery_token_ptr publish(const std::string& payload, int qos, bool retained);
 	/**
 	 * Publishes the specified message to this topic, but does not wait for
 	 * delivery of the message to complete.
 	 * @param msg
 	 * @return delivery_token
 	 */
-	idelivery_token_ptr publish(const_message_ptr msg);
+	delivery_token_ptr publish(const_message_ptr msg);
 	/**
 	 * Returns a string representation of this topic.
 	 * @return std::string

--- a/src/samples/async_publish.cpp
+++ b/src/samples/async_publish.cpp
@@ -58,7 +58,7 @@ public:
 	// We're not subscribed to anything, so this should never be called.
 	void message_arrived(const string& topic, mqtt::const_message_ptr msg) override {}
 
-	void delivery_complete(mqtt::idelivery_token_ptr tok) override {
+	void delivery_complete(mqtt::delivery_token_ptr tok) override {
 		cout << "\tDelivery complete for token: "
 			<< (tok ? tok->get_message_id() : -1) << endl;
 	}
@@ -72,12 +72,12 @@ public:
 class action_listener : public virtual mqtt::iaction_listener
 {
 protected:
-	void on_failure(const mqtt::itoken& tok) override {
+	void on_failure(const mqtt::token& tok) override {
 		cout << "\tListener failure for token: "
 			<< tok.get_message_id() << endl;
 	}
 
-	void on_success(const mqtt::itoken& tok) override {
+	void on_success(const mqtt::token& tok) override {
 		cout << "\tListener success for token: "
 			<< tok.get_message_id() << endl;
 	}
@@ -92,12 +92,12 @@ class delivery_action_listener : public action_listener
 {
 	atomic<bool> done_;
 
-	void on_failure(const mqtt::itoken& tok) override {
+	void on_failure(const mqtt::token& tok) override {
 		action_listener::on_failure(tok);
 		done_ = true;
 	}
 
-	void on_success(const mqtt::itoken& tok) override {
+	void on_success(const mqtt::token& tok) override {
 		action_listener::on_success(tok);
 		done_ = true;
 	}
@@ -129,7 +129,7 @@ int main(int argc, char* argv[])
 
 	try {
 		cout << "\nConnecting..." << endl;
-		mqtt::itoken_ptr conntok = client.connect(conopts);
+		mqtt::token_ptr conntok = client.connect(conopts);
 		cout << "Waiting for the connection..." << endl;
 		conntok->wait_for_completion();
 		cout << "  ...OK" << endl;
@@ -145,7 +145,7 @@ int main(int argc, char* argv[])
 		// Now try with itemized publish.
 
 		cout << "\nSending next message..." << endl;
-		mqtt::idelivery_token_ptr pubtok;
+		mqtt::delivery_token_ptr pubtok;
 		pubtok = client.publish(TOPIC, PAYLOAD2, strlen(PAYLOAD2), QOS, false);
 		cout << "  ...with token: " << pubtok->get_message_id() << endl;
 		cout << "  ...for message with " << pubtok->get_message()->get_payload().size()
@@ -176,7 +176,7 @@ int main(int argc, char* argv[])
 
 		// Double check that there are no pending tokens
 
-		vector<mqtt::idelivery_token_ptr> toks = client.get_pending_delivery_tokens();
+		vector<mqtt::delivery_token_ptr> toks = client.get_pending_delivery_tokens();
 		if (!toks.empty())
 			cout << "Error: There are pending delivery tokens!" << endl;
 

--- a/src/samples/async_subscribe.cpp
+++ b/src/samples/async_subscribe.cpp
@@ -35,14 +35,14 @@ class action_listener : public virtual mqtt::iaction_listener
 {
 	std::string name_;
 
-	void on_failure(const mqtt::itoken& tok) override {
+	void on_failure(const mqtt::token& tok) override {
 		std::cout << name_ << " failure";
 		if (tok.get_message_id() != 0)
 			std::cout << " for token: [" << tok.get_message_id() << "]" << std::endl;
 		std::cout << std::endl;
 	}
 
-	void on_success(const mqtt::itoken& tok) override {
+	void on_success(const mqtt::token& tok) override {
 		std::cout << name_ << " success";
 		if (tok.get_message_id() != 0)
 			std::cout << " for token: [" << tok.get_message_id() << "]" << std::endl;
@@ -84,7 +84,7 @@ class callback : public virtual mqtt::callback,
 	}
 
 	// Re-connection failure
-	void on_failure(const mqtt::itoken& tok) override {
+	void on_failure(const mqtt::token& tok) override {
 		std::cout << "Connection failed" << std::endl;
 		if (++nretry_ > 5)
 			exit(1);
@@ -92,7 +92,7 @@ class callback : public virtual mqtt::callback,
 	}
 
 	// Re-connection success
-	void on_success(const mqtt::itoken& tok) override {
+	void on_success(const mqtt::token& tok) override {
 		std::cout << "\nConnection success" << std::endl;
 		std::cout << "\nSubscribing to topic '" << TOPIC << "'\n"
 			<< "\tfor client " << CLIENTID
@@ -118,7 +118,7 @@ class callback : public virtual mqtt::callback,
 		std::cout << "\t'" << msg->to_str() << "'\n" << std::endl;
 	}
 
-	void delivery_complete(mqtt::idelivery_token_ptr token) override {}
+	void delivery_complete(mqtt::delivery_token_ptr token) override {}
 
 public:
 	callback(mqtt::async_client& cli, mqtt::connect_options& connOpts)

--- a/src/samples/ssl_publish.cpp
+++ b/src/samples/ssl_publish.cpp
@@ -62,7 +62,7 @@ public:
 	// We're not subscribed to anything, so this should never be called.
 	void message_arrived(const string& topic, mqtt::const_message_ptr msg) override {}
 
-	void delivery_complete(mqtt::idelivery_token_ptr tok) override {
+	void delivery_complete(mqtt::delivery_token_ptr tok) override {
 		cout << "\tDelivery complete for token: "
 			<< (tok ? tok->get_message_id() : -1) << endl;
 	}
@@ -96,7 +96,7 @@ int main(int argc, char* argv[])
 
 	try {
 		cout << "\nConnecting..." << endl;
-		mqtt::itoken_ptr conntok = client.connect(connopts);
+		mqtt::token_ptr conntok = client.connect(connopts);
 		cout << "Waiting for the connection..." << endl;
 		conntok->wait_for_completion();
 		cout << "  ...OK" << endl;
@@ -112,7 +112,7 @@ int main(int argc, char* argv[])
 		// Now try with itemized publish.
 
 		cout << "\nSending next message..." << endl;
-		mqtt::idelivery_token_ptr pubtok;
+		mqtt::delivery_token_ptr pubtok;
 		pubtok = client.publish(TOPIC, PAYLOAD2, strlen(PAYLOAD2), QOS, false);
 		pubtok->wait_for_completion(TIMEOUT);
 		cout << "  ...OK" << endl;
@@ -120,7 +120,7 @@ int main(int argc, char* argv[])
 
 		// Double check that there are no pending tokens
 
-		vector<mqtt::idelivery_token_ptr> toks = client.get_pending_delivery_tokens();
+		vector<mqtt::delivery_token_ptr> toks = client.get_pending_delivery_tokens();
 		if (!toks.empty())
 			cout << "Error: There are pending delivery tokens!" << endl;
 

--- a/src/samples/sync_publish.cpp
+++ b/src/samples/sync_publish.cpp
@@ -133,7 +133,7 @@ public:
 	void message_arrived(const std::string& topic,
 								 mqtt::const_message_ptr msg) override {}
 
-	void delivery_complete(mqtt::idelivery_token_ptr tok) override {
+	void delivery_complete(mqtt::delivery_token_ptr tok) override {
 		std::cout << "\n\t[Delivery complete for token: "
 			<< (tok ? tok->get_message_id() : -1) << "]" << std::endl;
 	}

--- a/src/topic.cpp
+++ b/src/topic.cpp
@@ -24,18 +24,18 @@ namespace mqtt {
 
 /////////////////////////////////////////////////////////////////////////////
 
-idelivery_token_ptr topic::publish(const void* payload, size_t n,
+delivery_token_ptr topic::publish(const void* payload, size_t n,
 								   int qos, bool retained)
 {
 	return cli_->publish(name_, payload, n, qos, retained);
 }
 
-idelivery_token_ptr topic::publish(const std::string& payload, int qos, bool retained)
+delivery_token_ptr topic::publish(const std::string& payload, int qos, bool retained)
 {
 	return publish(payload.data(), payload.length(), qos, retained);
 }
 
-idelivery_token_ptr topic::publish(const_message_ptr msg)
+delivery_token_ptr topic::publish(const_message_ptr msg)
 {
 	return cli_->publish(name_, msg);
 }

--- a/test/unit/async_client_test.h
+++ b/test/unit/async_client_test.h
@@ -157,7 +157,7 @@ public:
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		try {
-			mqtt::itoken_ptr token_conn = cli.connect();
+			mqtt::token_ptr token_conn = cli.connect();
 			CPPUNIT_ASSERT(token_conn);
 			token_conn->wait_for_completion();
 			CPPUNIT_ASSERT(cli.is_connected());
@@ -172,7 +172,7 @@ public:
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		mqtt::connect_options co;
-		mqtt::itoken_ptr token_conn { cli.connect(co) };
+		mqtt::token_ptr token_conn { cli.connect(co) };
 		CPPUNIT_ASSERT(token_conn);
 		token_conn->wait_for_completion();
 		CPPUNIT_ASSERT(cli.is_connected());
@@ -182,7 +182,7 @@ public:
 		mqtt::async_client cli { BAD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
-		mqtt::itoken_ptr token_conn { nullptr };
+		mqtt::token_ptr token_conn { nullptr };
 		mqtt::connect_options co;
 		mqtt::will_options wo;
 		wo.set_qos(BAD_QOS); // Invalid QoS causes connection failure
@@ -205,7 +205,7 @@ public:
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		mqtt::test::dummy_action_listener listener;
-		mqtt::itoken_ptr token_conn { cli.connect(&CONTEXT, listener) };
+		mqtt::token_ptr token_conn { cli.connect(&CONTEXT, listener) };
 		CPPUNIT_ASSERT(token_conn);
 		token_conn->wait_for_completion();
 		CPPUNIT_ASSERT(cli.is_connected());
@@ -219,7 +219,7 @@ public:
 
 		mqtt::connect_options co;
 		mqtt::test::dummy_action_listener listener;
-		mqtt::itoken_ptr token_conn { cli.connect(co, &CONTEXT, listener) };
+		mqtt::token_ptr token_conn { cli.connect(co, &CONTEXT, listener) };
 		CPPUNIT_ASSERT(token_conn);
 		token_conn->wait_for_completion();
 		CPPUNIT_ASSERT(cli.is_connected());
@@ -231,7 +231,7 @@ public:
 		mqtt::async_client cli { BAD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
-		mqtt::itoken_ptr token_conn { nullptr };
+		mqtt::token_ptr token_conn { nullptr };
 		mqtt::connect_options co;
 		mqtt::will_options wo;
 		wo.set_qos(BAD_QOS); // Invalid QoS causes connection failure
@@ -261,12 +261,12 @@ public:
 		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
-		mqtt::itoken_ptr token_conn { cli.connect() };
+		mqtt::token_ptr token_conn { cli.connect() };
 		CPPUNIT_ASSERT(token_conn);
 		token_conn->wait_for_completion();
 		CPPUNIT_ASSERT(cli.is_connected());
 
-		mqtt::itoken_ptr token_disconn { cli.disconnect() };
+		mqtt::token_ptr token_disconn { cli.disconnect() };
 		CPPUNIT_ASSERT(token_disconn);
 		token_disconn->wait_for_completion();
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
@@ -276,12 +276,12 @@ public:
 		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
-		mqtt::itoken_ptr token_conn { cli.connect() };
+		mqtt::token_ptr token_conn { cli.connect() };
 		CPPUNIT_ASSERT(token_conn);
 		token_conn->wait_for_completion();
 		CPPUNIT_ASSERT(cli.is_connected());
 
-		mqtt::itoken_ptr token_disconn { cli.disconnect(0) };
+		mqtt::token_ptr token_disconn { cli.disconnect(0) };
 		CPPUNIT_ASSERT(token_disconn);
 		token_disconn->wait_for_completion();
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
@@ -291,7 +291,7 @@ public:
 		mqtt::async_client cli { BAD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
-		mqtt::itoken_ptr token_disconn { nullptr };
+		mqtt::token_ptr token_disconn { nullptr };
 		int reason_code = MQTTASYNC_SUCCESS;
 		try {
 			token_disconn = cli.disconnect(0);
@@ -308,13 +308,13 @@ public:
 		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
-		mqtt::itoken_ptr token_conn { cli.connect() };
+		mqtt::token_ptr token_conn { cli.connect() };
 		CPPUNIT_ASSERT(token_conn);
 		token_conn->wait_for_completion();
 		CPPUNIT_ASSERT(cli.is_connected());
 
 		mqtt::test::dummy_action_listener listener;
-		mqtt::itoken_ptr token_disconn { cli.disconnect(&CONTEXT, listener) };
+		mqtt::token_ptr token_disconn { cli.disconnect(&CONTEXT, listener) };
 		CPPUNIT_ASSERT(token_disconn);
 		token_disconn->wait_for_completion();
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
@@ -325,13 +325,13 @@ public:
 		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
-		mqtt::itoken_ptr token_conn { cli.connect() };
+		mqtt::token_ptr token_conn { cli.connect() };
 		CPPUNIT_ASSERT(token_conn);
 		token_conn->wait_for_completion();
 		CPPUNIT_ASSERT(cli.is_connected());
 
 		mqtt::test::dummy_action_listener listener;
-		mqtt::itoken_ptr token_disconn { cli.disconnect(0, &CONTEXT, listener) };
+		mqtt::token_ptr token_disconn { cli.disconnect(0, &CONTEXT, listener) };
 		CPPUNIT_ASSERT(token_disconn);
 		token_disconn->wait_for_completion();
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
@@ -342,7 +342,7 @@ public:
 		mqtt::async_client cli { BAD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
-		mqtt::itoken_ptr token_disconn { nullptr };
+		mqtt::token_ptr token_disconn { nullptr };
 		mqtt::test::dummy_action_listener listener;
 		int reason_code = MQTTASYNC_SUCCESS;
 		try {
@@ -368,17 +368,17 @@ public:
 		CPPUNIT_ASSERT_EQUAL(1, GOOD_QOS_COLL[1]);
 		CPPUNIT_ASSERT_EQUAL(2, GOOD_QOS_COLL[2]);
 
-		mqtt::itoken_ptr token_conn { cli.connect() };
+		mqtt::token_ptr token_conn { cli.connect() };
 		CPPUNIT_ASSERT(token_conn);
 		token_conn->wait_for_completion();
 		CPPUNIT_ASSERT(cli.is_connected());
 
 		// NOTE: async_client::publish() is the only method that adds
-		// idelivery_token via async_client::add_token(idelivery_token_ptr tok).
-		// The other functions add itoken async_client::add_token(itoken_ptr tok).
+		// delivery_token via async_client::add_token(delivery_token_ptr tok).
+		// The other functions add token async_client::add_token(token_ptr tok).
 
-		mqtt::idelivery_token_ptr token_pub { nullptr };
-		mqtt::idelivery_token_ptr token_pending { nullptr };
+		mqtt::delivery_token_ptr token_pub { nullptr };
+		mqtt::delivery_token_ptr token_pending { nullptr };
 
 		// NOTE: message IDs are 16-bit numbers sequentially incremented, from
 		// 1 to 65535 (MAX_MSG_ID). See MQTTAsync_assignMsgId() at Paho MQTT C.
@@ -419,7 +419,7 @@ public:
 		token_pending = cli.get_pending_delivery_token(message_id++);
 		CPPUNIT_ASSERT(!token_pending);
 
-		mqtt::itoken_ptr token_disconn { cli.disconnect() };
+		mqtt::token_ptr token_disconn { cli.disconnect() };
 		CPPUNIT_ASSERT(token_disconn);
 		token_disconn->wait_for_completion();
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
@@ -433,16 +433,16 @@ public:
 		CPPUNIT_ASSERT_EQUAL(1, GOOD_QOS_COLL[1]);
 		CPPUNIT_ASSERT_EQUAL(2, GOOD_QOS_COLL[2]);
 
-		mqtt::itoken_ptr token_conn { cli.connect() };
+		mqtt::token_ptr token_conn { cli.connect() };
 		CPPUNIT_ASSERT(token_conn);
 		token_conn->wait_for_completion();
 		CPPUNIT_ASSERT(cli.is_connected());
 
-		mqtt::idelivery_token_ptr token_pub { nullptr };
+		mqtt::delivery_token_ptr token_pub { nullptr };
 
 		// NOTE: async_client::publish() is the only method that adds
-		// idelivery_token via async_client::add_token(idelivery_token_ptr tok).
-		// The other functions add itoken async_client::add_token(itoken_ptr tok).
+		// delivery_token via async_client::add_token(delivery_token_ptr tok).
+		// The other functions add token async_client::add_token(token_ptr tok).
 
 		// Messages with QOS=0 are NOT kept by the library
 		mqtt::message_ptr msg0 { mqtt::make_message(PAYLOAD, GOOD_QOS_COLL[0], RETAINED) };
@@ -461,10 +461,10 @@ public:
 
 		// NOTE: Only tokens for messages with QOS=1 and QOS=2 are kept. That's
 		// why the vector's size does not account for QOS=0 message tokens
-		std::vector<mqtt::idelivery_token_ptr> tokens_pending { cli.get_pending_delivery_tokens() };
+		std::vector<mqtt::delivery_token_ptr> tokens_pending { cli.get_pending_delivery_tokens() };
 		CPPUNIT_ASSERT_EQUAL(2, static_cast<int>(tokens_pending.size()));
 
-		mqtt::itoken_ptr token_disconn { cli.disconnect() };
+		mqtt::token_ptr token_disconn { cli.disconnect() };
 		CPPUNIT_ASSERT(token_disconn);
 		token_disconn->wait_for_completion();
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
@@ -478,17 +478,17 @@ public:
 		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
-		mqtt::itoken_ptr token_conn { cli.connect() };
+		mqtt::token_ptr token_conn { cli.connect() };
 		CPPUNIT_ASSERT(token_conn);
 		token_conn->wait_for_completion();
 		CPPUNIT_ASSERT(cli.is_connected());
 
 		mqtt::message_ptr msg { mqtt::make_message(PAYLOAD) };
-		mqtt::idelivery_token_ptr token_pub { cli.publish(TOPIC, msg) };
+		mqtt::delivery_token_ptr token_pub { cli.publish(TOPIC, msg) };
 		CPPUNIT_ASSERT(token_pub);
 		token_pub->wait_for_completion(TIMEOUT);
 
-		mqtt::itoken_ptr token_disconn { cli.disconnect() };
+		mqtt::token_ptr token_disconn { cli.disconnect() };
 		CPPUNIT_ASSERT(token_disconn);
 		token_disconn->wait_for_completion();
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
@@ -501,7 +501,7 @@ public:
 		int reason_code = MQTTASYNC_SUCCESS;
 		try {
 			mqtt::message_ptr msg { mqtt::make_message(PAYLOAD) };
-			mqtt::idelivery_token_ptr token_pub { cli.publish(TOPIC, msg) };
+			mqtt::delivery_token_ptr token_pub { cli.publish(TOPIC, msg) };
 			CPPUNIT_ASSERT(token_pub);
 			token_pub->wait_for_completion(TIMEOUT);
 		}
@@ -515,19 +515,19 @@ public:
 		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
-		mqtt::itoken_ptr token_conn { cli.connect() };
+		mqtt::token_ptr token_conn { cli.connect() };
 		CPPUNIT_ASSERT(token_conn);
 		token_conn->wait_for_completion();
 		CPPUNIT_ASSERT(cli.is_connected());
 
 		mqtt::message_ptr msg { mqtt::make_message(PAYLOAD) };
 		mqtt::test::dummy_action_listener listener;
-		mqtt::idelivery_token_ptr token_pub { cli.publish(TOPIC, msg, &CONTEXT, listener) };
+		mqtt::delivery_token_ptr token_pub { cli.publish(TOPIC, msg, &CONTEXT, listener) };
 		CPPUNIT_ASSERT(token_pub);
 		token_pub->wait_for_completion(TIMEOUT);
 		CPPUNIT_ASSERT_EQUAL(CONTEXT, *static_cast<int*>(token_pub->get_user_context()));
 
-		mqtt::itoken_ptr token_disconn { cli.disconnect() };
+		mqtt::token_ptr token_disconn { cli.disconnect() };
 		CPPUNIT_ASSERT(token_disconn);
 		token_disconn->wait_for_completion();
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
@@ -541,7 +541,7 @@ public:
 		try {
 			mqtt::message_ptr msg { mqtt::make_message(PAYLOAD) };
 			mqtt::test::dummy_action_listener listener;
-			mqtt::idelivery_token_ptr token_pub { cli.publish(TOPIC, msg, &CONTEXT, listener) };
+			mqtt::delivery_token_ptr token_pub { cli.publish(TOPIC, msg, &CONTEXT, listener) };
 			CPPUNIT_ASSERT(token_pub);
 			token_pub->wait_for_completion(TIMEOUT);
 		}
@@ -555,18 +555,18 @@ public:
 		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
-		mqtt::itoken_ptr token_conn { cli.connect() };
+		mqtt::token_ptr token_conn { cli.connect() };
 		CPPUNIT_ASSERT(token_conn);
 		token_conn->wait_for_completion();
 		CPPUNIT_ASSERT(cli.is_connected());
 
 		const void* payload { PAYLOAD.c_str() };
 		const size_t payload_size { PAYLOAD.size() };
-		mqtt::idelivery_token_ptr token_pub { cli.publish(TOPIC, payload, payload_size, GOOD_QOS, RETAINED) };
+		mqtt::delivery_token_ptr token_pub { cli.publish(TOPIC, payload, payload_size, GOOD_QOS, RETAINED) };
 		CPPUNIT_ASSERT(token_pub);
 		token_pub->wait_for_completion(TIMEOUT);
 
-		mqtt::itoken_ptr token_disconn { cli.disconnect() };
+		mqtt::token_ptr token_disconn { cli.disconnect() };
 		CPPUNIT_ASSERT(token_disconn);
 		token_disconn->wait_for_completion();
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
@@ -576,7 +576,7 @@ public:
 		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
-		mqtt::itoken_ptr token_conn { cli.connect() };
+		mqtt::token_ptr token_conn { cli.connect() };
 		CPPUNIT_ASSERT(token_conn);
 		token_conn->wait_for_completion();
 		CPPUNIT_ASSERT(cli.is_connected());
@@ -584,12 +584,12 @@ public:
 		const void* payload { PAYLOAD.c_str() };
 		const size_t payload_size { PAYLOAD.size() };
 		mqtt::test::dummy_action_listener listener;
-		mqtt::idelivery_token_ptr token_pub { cli.publish(TOPIC, payload, payload_size, GOOD_QOS, RETAINED, &CONTEXT, listener) };
+		mqtt::delivery_token_ptr token_pub { cli.publish(TOPIC, payload, payload_size, GOOD_QOS, RETAINED, &CONTEXT, listener) };
 		CPPUNIT_ASSERT(token_pub);
 		token_pub->wait_for_completion(TIMEOUT);
 		CPPUNIT_ASSERT_EQUAL(CONTEXT, *static_cast<int*>(token_pub->get_user_context()));
 
-		mqtt::itoken_ptr token_disconn { cli.disconnect() };
+		mqtt::token_ptr token_disconn { cli.disconnect() };
 		CPPUNIT_ASSERT(token_disconn);
 		token_disconn->wait_for_completion();
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
@@ -617,16 +617,16 @@ public:
 		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
-		mqtt::itoken_ptr token_conn { cli.connect() };
+		mqtt::token_ptr token_conn { cli.connect() };
 		CPPUNIT_ASSERT(token_conn);
 		token_conn->wait_for_completion();
 		CPPUNIT_ASSERT(cli.is_connected());
 
-		mqtt::itoken_ptr token_sub { cli.subscribe(TOPIC, GOOD_QOS) };
+		mqtt::token_ptr token_sub { cli.subscribe(TOPIC, GOOD_QOS) };
 		CPPUNIT_ASSERT(token_sub);
 		token_sub->wait_for_completion(TIMEOUT);
 
-		mqtt::itoken_ptr token_disconn { cli.disconnect() };
+		mqtt::token_ptr token_disconn { cli.disconnect() };
 		CPPUNIT_ASSERT(token_disconn);
 		token_disconn->wait_for_completion();
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
@@ -638,7 +638,7 @@ public:
 
 		int reason_code = MQTTASYNC_SUCCESS;
 		try {
-			mqtt::itoken_ptr token_sub { cli.subscribe(TOPIC, BAD_QOS) };
+			mqtt::token_ptr token_sub { cli.subscribe(TOPIC, BAD_QOS) };
 			CPPUNIT_ASSERT(token_sub);
 			token_sub->wait_for_completion(TIMEOUT);
 		}
@@ -652,18 +652,18 @@ public:
 		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
-		mqtt::itoken_ptr token_conn { cli.connect() };
+		mqtt::token_ptr token_conn { cli.connect() };
 		CPPUNIT_ASSERT(token_conn);
 		token_conn->wait_for_completion();
 		CPPUNIT_ASSERT(cli.is_connected());
 
 		mqtt::test::dummy_action_listener listener;
-		mqtt::itoken_ptr token_sub { cli.subscribe(TOPIC, GOOD_QOS, &CONTEXT, listener) };
+		mqtt::token_ptr token_sub { cli.subscribe(TOPIC, GOOD_QOS, &CONTEXT, listener) };
 		CPPUNIT_ASSERT(token_sub);
 		token_sub->wait_for_completion(TIMEOUT);
 		CPPUNIT_ASSERT_EQUAL(CONTEXT, *static_cast<int*>(token_sub->get_user_context()));
 
-		mqtt::itoken_ptr token_disconn { cli.disconnect() };
+		mqtt::token_ptr token_disconn { cli.disconnect() };
 		CPPUNIT_ASSERT(token_disconn);
 		token_disconn->wait_for_completion();
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
@@ -676,7 +676,7 @@ public:
 		int reason_code = MQTTASYNC_SUCCESS;
 		try {
 			mqtt::test::dummy_action_listener listener;
-			mqtt::itoken_ptr token_sub { cli.subscribe(TOPIC, BAD_QOS, &CONTEXT, listener) };
+			mqtt::token_ptr token_sub { cli.subscribe(TOPIC, BAD_QOS, &CONTEXT, listener) };
 			CPPUNIT_ASSERT(token_sub);
 			token_sub->wait_for_completion(TIMEOUT);
 		}
@@ -690,16 +690,16 @@ public:
 		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
-		mqtt::itoken_ptr token_conn { cli.connect() };
+		mqtt::token_ptr token_conn { cli.connect() };
 		CPPUNIT_ASSERT(token_conn);
 		token_conn->wait_for_completion();
 		CPPUNIT_ASSERT(cli.is_connected());
 
-		mqtt::itoken_ptr token_sub { cli.subscribe(TOPIC_COLL, GOOD_QOS_COLL) };
+		mqtt::token_ptr token_sub { cli.subscribe(TOPIC_COLL, GOOD_QOS_COLL) };
 		CPPUNIT_ASSERT(token_sub);
 		token_sub->wait_for_completion(TIMEOUT);
 
-		mqtt::itoken_ptr token_disconn { cli.disconnect() };
+		mqtt::token_ptr token_disconn { cli.disconnect() };
 		CPPUNIT_ASSERT(token_disconn);
 		token_disconn->wait_for_completion();
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
@@ -710,7 +710,7 @@ public:
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		try {
-			mqtt::itoken_ptr token_sub { cli.subscribe(TOPIC_COLL, BAD_QOS_COLL) };
+			mqtt::token_ptr token_sub { cli.subscribe(TOPIC_COLL, BAD_QOS_COLL) };
 			CPPUNIT_ASSERT(token_sub);
 			token_sub->wait_for_completion(TIMEOUT);
 		}
@@ -718,7 +718,7 @@ public:
 
 		int reason_code = MQTTASYNC_SUCCESS;
 		try {
-			mqtt::itoken_ptr token_sub { cli.subscribe(TOPIC_COLL, GOOD_QOS_COLL) };
+			mqtt::token_ptr token_sub { cli.subscribe(TOPIC_COLL, GOOD_QOS_COLL) };
 			CPPUNIT_ASSERT(token_sub);
 			token_sub->wait_for_completion(TIMEOUT);
 		}
@@ -732,18 +732,18 @@ public:
 		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
-		mqtt::itoken_ptr token_conn { cli.connect() };
+		mqtt::token_ptr token_conn { cli.connect() };
 		CPPUNIT_ASSERT(token_conn);
 		token_conn->wait_for_completion();
 		CPPUNIT_ASSERT(cli.is_connected());
 
 		mqtt::test::dummy_action_listener listener;
-		mqtt::itoken_ptr token_sub { cli.subscribe(TOPIC_COLL, GOOD_QOS_COLL, &CONTEXT, listener) };
+		mqtt::token_ptr token_sub { cli.subscribe(TOPIC_COLL, GOOD_QOS_COLL, &CONTEXT, listener) };
 		CPPUNIT_ASSERT(token_sub);
 		token_sub->wait_for_completion(TIMEOUT);
 		CPPUNIT_ASSERT_EQUAL(CONTEXT, *static_cast<int*>(token_sub->get_user_context()));
 
-		mqtt::itoken_ptr token_disconn { cli.disconnect() };
+		mqtt::token_ptr token_disconn { cli.disconnect() };
 		CPPUNIT_ASSERT(token_disconn);
 		token_disconn->wait_for_completion();
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
@@ -756,7 +756,7 @@ public:
 		mqtt::test::dummy_action_listener listener;
 
 		try {
-			mqtt::itoken_ptr token_sub { cli.subscribe(TOPIC_COLL, BAD_QOS_COLL, &CONTEXT, listener) };
+			mqtt::token_ptr token_sub { cli.subscribe(TOPIC_COLL, BAD_QOS_COLL, &CONTEXT, listener) };
 			CPPUNIT_ASSERT(token_sub);
 			token_sub->wait_for_completion(TIMEOUT);
 		}
@@ -764,7 +764,7 @@ public:
 
 		int reason_code = MQTTASYNC_SUCCESS;
 		try {
-			mqtt::itoken_ptr token_sub { cli.subscribe(TOPIC_COLL, GOOD_QOS_COLL, &CONTEXT, listener) };
+			mqtt::token_ptr token_sub { cli.subscribe(TOPIC_COLL, GOOD_QOS_COLL, &CONTEXT, listener) };
 			CPPUNIT_ASSERT(token_sub);
 			token_sub->wait_for_completion(TIMEOUT);
 		}
@@ -782,16 +782,16 @@ public:
 		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
-		mqtt::itoken_ptr token_conn { cli.connect() };
+		mqtt::token_ptr token_conn { cli.connect() };
 		CPPUNIT_ASSERT(token_conn);
 		token_conn->wait_for_completion();
 		CPPUNIT_ASSERT(cli.is_connected());
 
-		mqtt::itoken_ptr token_unsub { cli.unsubscribe(TOPIC) };
+		mqtt::token_ptr token_unsub { cli.unsubscribe(TOPIC) };
 		CPPUNIT_ASSERT(token_unsub);
 		token_unsub->wait_for_completion(TIMEOUT);
 
-		mqtt::itoken_ptr token_disconn { cli.disconnect() };
+		mqtt::token_ptr token_disconn { cli.disconnect() };
 		CPPUNIT_ASSERT(token_disconn);
 		token_disconn->wait_for_completion();
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
@@ -803,7 +803,7 @@ public:
 
 		int reason_code = MQTTASYNC_SUCCESS;
 		try {
-			mqtt::itoken_ptr token_unsub { cli.unsubscribe(TOPIC) };
+			mqtt::token_ptr token_unsub { cli.unsubscribe(TOPIC) };
 			CPPUNIT_ASSERT(token_unsub);
 			token_unsub->wait_for_completion(TIMEOUT);
 		}
@@ -817,18 +817,18 @@ public:
 		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
-		mqtt::itoken_ptr token_conn { cli.connect() };
+		mqtt::token_ptr token_conn { cli.connect() };
 		CPPUNIT_ASSERT(token_conn);
 		token_conn->wait_for_completion();
 		CPPUNIT_ASSERT(cli.is_connected());
 
 		mqtt::test::dummy_action_listener listener;
-		mqtt::itoken_ptr token_unsub { cli.unsubscribe(TOPIC, &CONTEXT, listener) };
+		mqtt::token_ptr token_unsub { cli.unsubscribe(TOPIC, &CONTEXT, listener) };
 		CPPUNIT_ASSERT(token_unsub);
 		token_unsub->wait_for_completion(TIMEOUT);
 		CPPUNIT_ASSERT_EQUAL(CONTEXT, *static_cast<int*>(token_unsub->get_user_context()));
 
-		mqtt::itoken_ptr token_disconn { cli.disconnect() };
+		mqtt::token_ptr token_disconn { cli.disconnect() };
 		CPPUNIT_ASSERT(token_disconn);
 		token_disconn->wait_for_completion();
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
@@ -841,7 +841,7 @@ public:
 		int reason_code = MQTTASYNC_SUCCESS;
 		try {
 			mqtt::test::dummy_action_listener listener;
-			mqtt::itoken_ptr token_unsub { cli.unsubscribe(TOPIC, &CONTEXT, listener) };
+			mqtt::token_ptr token_unsub { cli.unsubscribe(TOPIC, &CONTEXT, listener) };
 			CPPUNIT_ASSERT(token_unsub);
 			token_unsub->wait_for_completion(TIMEOUT);
 		}
@@ -855,16 +855,16 @@ public:
 		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
-		mqtt::itoken_ptr token_conn { cli.connect() };
+		mqtt::token_ptr token_conn { cli.connect() };
 		CPPUNIT_ASSERT(token_conn);
 		token_conn->wait_for_completion();
 		CPPUNIT_ASSERT(cli.is_connected());
 
-		mqtt::itoken_ptr token_unsub { cli.unsubscribe(TOPIC_COLL) };
+		mqtt::token_ptr token_unsub { cli.unsubscribe(TOPIC_COLL) };
 		CPPUNIT_ASSERT(token_unsub);
 		token_unsub->wait_for_completion(TIMEOUT);
 
-		mqtt::itoken_ptr token_disconn { cli.disconnect() };
+		mqtt::token_ptr token_disconn { cli.disconnect() };
 		CPPUNIT_ASSERT(token_disconn);
 		token_disconn->wait_for_completion();
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
@@ -876,7 +876,7 @@ public:
 
 		int reason_code = MQTTASYNC_SUCCESS;
 		try {
-			mqtt::itoken_ptr token_unsub { cli.unsubscribe(TOPIC_COLL) };
+			mqtt::token_ptr token_unsub { cli.unsubscribe(TOPIC_COLL) };
 			CPPUNIT_ASSERT(token_unsub);
 			token_unsub->wait_for_completion(TIMEOUT);
 		}
@@ -890,18 +890,18 @@ public:
 		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
-		mqtt::itoken_ptr token_conn { cli.connect() };
+		mqtt::token_ptr token_conn { cli.connect() };
 		CPPUNIT_ASSERT(token_conn);
 		token_conn->wait_for_completion();
 		CPPUNIT_ASSERT(cli.is_connected());
 
 		mqtt::test::dummy_action_listener listener;
-		mqtt::itoken_ptr token_unsub { cli.unsubscribe(TOPIC_COLL, &CONTEXT, listener) };
+		mqtt::token_ptr token_unsub { cli.unsubscribe(TOPIC_COLL, &CONTEXT, listener) };
 		CPPUNIT_ASSERT(token_unsub);
 		token_unsub->wait_for_completion(TIMEOUT);
 		CPPUNIT_ASSERT_EQUAL(CONTEXT, *static_cast<int*>(token_unsub->get_user_context()));
 
-		mqtt::itoken_ptr token_disconn { cli.disconnect() };
+		mqtt::token_ptr token_disconn { cli.disconnect() };
 		CPPUNIT_ASSERT(token_disconn);
 		token_disconn->wait_for_completion();
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
@@ -914,7 +914,7 @@ public:
 		mqtt::test::dummy_action_listener listener;
 		int reason_code = MQTTASYNC_SUCCESS;
 		try {
-			mqtt::itoken_ptr token_unsub { cli.unsubscribe(TOPIC_COLL, &CONTEXT, listener) };
+			mqtt::token_ptr token_unsub { cli.unsubscribe(TOPIC_COLL, &CONTEXT, listener) };
 			CPPUNIT_ASSERT(token_unsub);
 			token_unsub->wait_for_completion(TIMEOUT);
 		}

--- a/test/unit/dummy_action_listener.h
+++ b/test/unit/dummy_action_listener.h
@@ -33,11 +33,11 @@ public:
 	bool on_success_called { false };
 	bool on_failure_called { false };
 
-	void on_success(const mqtt::itoken& token) override {
+	void on_success(const mqtt::token& token) override {
 		on_success_called = true;
 	}
 
-	void on_failure(const mqtt::itoken& token) override {
+	void on_failure(const mqtt::token& token) override {
 		on_failure_called = true;
 	}
 

--- a/test/unit/dummy_async_client.h
+++ b/test/unit/dummy_async_client.h
@@ -34,50 +34,50 @@ namespace test {
 class dummy_async_client : public mqtt::iasync_client
 {
 public:
-	void remove_token(mqtt::itoken* tok) override {}
+	void remove_token(mqtt::token* tok) override {}
 
-	mqtt::itoken_ptr connect() override {
-		return mqtt::itoken_ptr{};
+	mqtt::token_ptr connect() override {
+		return mqtt::token_ptr{};
 	}
 
-	mqtt::itoken_ptr connect(mqtt::connect_options options) override {
-		return mqtt::itoken_ptr{};
+	mqtt::token_ptr connect(mqtt::connect_options options) override {
+		return mqtt::token_ptr{};
 	}
 
-	mqtt::itoken_ptr connect(mqtt::connect_options options, void* userContext, mqtt::iaction_listener& cb) override {
-		return mqtt::itoken_ptr{};
+	mqtt::token_ptr connect(mqtt::connect_options options, void* userContext, mqtt::iaction_listener& cb) override {
+		return mqtt::token_ptr{};
 	}
 
-	mqtt::itoken_ptr connect(void* userContext, mqtt::iaction_listener& cb) override {
-		return mqtt::itoken_ptr{};
+	mqtt::token_ptr connect(void* userContext, mqtt::iaction_listener& cb) override {
+		return mqtt::token_ptr{};
 	}
 
-	mqtt::itoken_ptr disconnect() override {
-		return mqtt::itoken_ptr{};
+	mqtt::token_ptr disconnect() override {
+		return mqtt::token_ptr{};
 	}
 
-	mqtt::itoken_ptr disconnect(disconnect_options) override {
-		return mqtt::itoken_ptr{};
+	mqtt::token_ptr disconnect(disconnect_options) override {
+		return mqtt::token_ptr{};
 	}
 
-	mqtt::itoken_ptr disconnect(int timeout) override {
-		return mqtt::itoken_ptr{};
+	mqtt::token_ptr disconnect(int timeout) override {
+		return mqtt::token_ptr{};
 	}
 
-	mqtt::itoken_ptr disconnect(int timeout, void* userContext, mqtt::iaction_listener& cb) override {
-		return mqtt::itoken_ptr{};
+	mqtt::token_ptr disconnect(int timeout, void* userContext, mqtt::iaction_listener& cb) override {
+		return mqtt::token_ptr{};
 	}
 
-	mqtt::itoken_ptr disconnect(void* userContext, mqtt::iaction_listener& cb) override {
-		return mqtt::itoken_ptr{};
+	mqtt::token_ptr disconnect(void* userContext, mqtt::iaction_listener& cb) override {
+		return mqtt::token_ptr{};
 	}
 
-	mqtt::idelivery_token_ptr get_pending_delivery_token(int msgID) const override {
-		return mqtt::idelivery_token_ptr{};
+	mqtt::delivery_token_ptr get_pending_delivery_token(int msgID) const override {
+		return mqtt::delivery_token_ptr{};
 	}
 
-	std::vector<mqtt::idelivery_token_ptr> get_pending_delivery_tokens() const override {
-		return std::vector<mqtt::idelivery_token_ptr>{};
+	std::vector<mqtt::delivery_token_ptr> get_pending_delivery_tokens() const override {
+		return std::vector<mqtt::delivery_token_ptr>{};
 	};
 
 	std::string get_client_id() const override {
@@ -92,66 +92,66 @@ public:
 		return true;
 	};
 
-	mqtt::idelivery_token_ptr publish(const std::string& topic, const void* payload,
+	mqtt::delivery_token_ptr publish(const std::string& topic, const void* payload,
 			size_t n, int qos, bool retained) override {
 		auto msg = mqtt::make_message(payload, n, qos, retained);
 		return publish(topic, msg);
 	};
 
-	mqtt::idelivery_token_ptr publish(const std::string& topic,
+	mqtt::delivery_token_ptr publish(const std::string& topic,
 			const void* payload, size_t n,
 			int qos, bool retained, void* userContext,
 			mqtt::iaction_listener& cb) override {
-		return mqtt::idelivery_token_ptr{};
+		return mqtt::delivery_token_ptr{};
 	}
 
-	mqtt::idelivery_token_ptr publish(const std::string& topic, mqtt::const_message_ptr msg) override {
+	mqtt::delivery_token_ptr publish(const std::string& topic, mqtt::const_message_ptr msg) override {
 		return std::make_shared<mqtt::delivery_token>(*this, topic, msg);
 	}
 
-	mqtt::idelivery_token_ptr publish(const std::string& topic, mqtt::const_message_ptr msg,
+	mqtt::delivery_token_ptr publish(const std::string& topic, mqtt::const_message_ptr msg,
 			void* userContext, mqtt::iaction_listener& cb) override {
-		return mqtt::idelivery_token_ptr{};
+		return mqtt::delivery_token_ptr{};
 	}
 
 	void set_callback(mqtt::callback& cb) override {}
 
-	mqtt::itoken_ptr subscribe(const topic_filter_collection& topicFilters,
+	mqtt::token_ptr subscribe(const topic_filter_collection& topicFilters,
 			const qos_collection& qos) override {
-		return mqtt::itoken_ptr{};
+		return mqtt::token_ptr{};
 	}
 
-	mqtt::itoken_ptr subscribe(const topic_filter_collection& topicFilters,
+	mqtt::token_ptr subscribe(const topic_filter_collection& topicFilters,
 			const qos_collection& qos,
 			void* userContext, mqtt::iaction_listener& callback) override {
-		return mqtt::itoken_ptr{};
+		return mqtt::token_ptr{};
 	}
 
-	mqtt::itoken_ptr subscribe(const std::string& topicFilter, int qos) override {
-		return mqtt::itoken_ptr{};
+	mqtt::token_ptr subscribe(const std::string& topicFilter, int qos) override {
+		return mqtt::token_ptr{};
 	}
 
-	mqtt::itoken_ptr subscribe(const std::string& topicFilter, int qos,
+	mqtt::token_ptr subscribe(const std::string& topicFilter, int qos,
 			void* userContext, mqtt::iaction_listener& callback) override {
-		return mqtt::itoken_ptr{};
+		return mqtt::token_ptr{};
 	}
 
-	mqtt::itoken_ptr unsubscribe(const std::string& topicFilter) override {
-		return mqtt::itoken_ptr{};
+	mqtt::token_ptr unsubscribe(const std::string& topicFilter) override {
+		return mqtt::token_ptr{};
 	}
 
-	mqtt::itoken_ptr unsubscribe(const topic_filter_collection& topicFilters) override {
-		return mqtt::itoken_ptr{};
+	mqtt::token_ptr unsubscribe(const topic_filter_collection& topicFilters) override {
+		return mqtt::token_ptr{};
 	}
 
-	mqtt::itoken_ptr unsubscribe(const topic_filter_collection& topicFilters,
+	mqtt::token_ptr unsubscribe(const topic_filter_collection& topicFilters,
 			void* userContext, mqtt::iaction_listener& cb) override {
-		return mqtt::itoken_ptr{};
+		return mqtt::token_ptr{};
 	}
 
-	mqtt::itoken_ptr unsubscribe(const std::string& topicFilter,
+	mqtt::token_ptr unsubscribe(const std::string& topicFilter,
 			void* userContext, mqtt::iaction_listener& cb) override {
-		return mqtt::itoken_ptr{};
+		return mqtt::token_ptr{};
 	}
 };
 

--- a/test/unit/dummy_callback.h
+++ b/test/unit/dummy_callback.h
@@ -42,7 +42,7 @@ public:
 		message_arrived_called = true;
 	}
 
-	void delivery_complete(mqtt::idelivery_token_ptr tok) override {
+	void delivery_complete(mqtt::delivery_token_ptr tok) override {
 		delivery_complete_called = true;
 	}
 

--- a/test/unit/topic_test.h
+++ b/test/unit/topic_test.h
@@ -73,7 +73,7 @@ public:
 
 		mqtt::const_message_ptr msg_in { new mqtt::message { "message" } };
 
-		mqtt::idelivery_token_ptr token { topic.publish(msg_in) };
+		mqtt::delivery_token_ptr token { topic.publish(msg_in) };
 		CPPUNIT_ASSERT(token);
 
 		mqtt::const_message_ptr msg_out { token->get_message() };
@@ -94,7 +94,7 @@ public:
 		std::string payload { "message" };
 		int qos { 1 };
 
-		mqtt::idelivery_token_ptr token { topic.publish(payload, qos, false) };
+		mqtt::delivery_token_ptr token { topic.publish(payload, qos, false) };
 		CPPUNIT_ASSERT(token);
 
 		mqtt::const_message_ptr msg_out { token->get_message() };
@@ -115,7 +115,7 @@ public:
 		std::size_t payload_size { payload.size() };
 		int qos { 2 };
 
-		mqtt::idelivery_token_ptr token = topic.publish(payload.c_str(), payload_size, qos, false);
+		mqtt::delivery_token_ptr token = topic.publish(payload.c_str(), payload_size, qos, false);
 		CPPUNIT_ASSERT(token);
 
 		mqtt::const_message_ptr msg_out = token->get_message();


### PR DESCRIPTION
This removes the token interfaces, `itoken` and `idelivery_token` and uses `token` and `delivery_token` objects directly in their place, mostly through shared pointers, `token_ptr` and `delivery_token_ptr`, respectively.
#83 