### PR TITLE
Travis runs test cases using an external broker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,14 +136,14 @@ matrix:
 
 script:
   # Test Makefile building
-  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && make clean && make CXX=$COMPILER PAHO_C_INC_DIR=/tmp/paho-c/include/ PAHO_C_LIB_DIR=/tmp/paho-c/lib PAHO_CPP_INC_DIR=../../src PAHO_CPP_LIB_DIR=../../lib check
-  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && make clean && make CXX=$COMPILER PAHO_C_INC_DIR=/tmp/paho-c/include/ PAHO_C_LIB_DIR=/tmp/paho-c/lib PAHO_CPP_INC_DIR=../../src PAHO_CPP_LIB_DIR=../../lib SSL=1 check
+  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && make clean && make CXX=$COMPILER PAHO_C_INC_DIR=/tmp/paho-c/include/ PAHO_C_LIB_DIR=/tmp/paho-c/lib PAHO_CPP_INC_DIR=../../src PAHO_CPP_LIB_DIR=../../lib TEST_EXTERNAL_SERVER=1 check
+  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && make clean && make CXX=$COMPILER PAHO_C_INC_DIR=/tmp/paho-c/include/ PAHO_C_LIB_DIR=/tmp/paho-c/lib PAHO_CPP_INC_DIR=../../src PAHO_CPP_LIB_DIR=../../lib TEST_EXTERNAL_SERVER=1 SSL=1 check
   # Test CMake building
   - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && rm -rf build_cmake && mkdir build_cmake && cd build_cmake && cmake -DCMAKE_CXX_COMPILER=$COMPILER -DCMAKE_INSTALL_PREFIX=/tmp/paho-cpp -DPAHO_MQTT_C_PATH=/tmp/paho-c -DPAHO_BUILD_SAMPLES=ON -DPAHO_BUILD_STATIC=ON -DPAHO_BUILD_DOCUMENTATION=OFF -DPAHO_WITH_SSL=OFF .. && make && make install; cd ..
   - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && rm -rf build_cmake && mkdir build_cmake && cd build_cmake && cmake -DCMAKE_CXX_COMPILER=$COMPILER -DCMAKE_INSTALL_PREFIX=/tmp/paho-cpp -DPAHO_MQTT_C_PATH=/tmp/paho-c -DPAHO_BUILD_SAMPLES=ON -DPAHO_BUILD_STATIC=ON -DPAHO_BUILD_DOCUMENTATION=ON  -DPAHO_WITH_SSL=ON  .. && make && make install; cd ..
   # Test Autotools building
-  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && ./bootstrap && rm -rf build_autotools/ && mkdir build_autotools/ && cd build_autotools/ && ../configure CXX=$COMPILER --with-paho-mqtt-c=/tmp/paho-c/ --enable-samples=yes --enable-static=yes --enable-doc=no  --with-ssl=no  && make && make check; cat test-suite.log; cd -
-  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && ./bootstrap && rm -rf build_autotools/ && mkdir build_autotools/ && cd build_autotools/ && ../configure CXX=$COMPILER --with-paho-mqtt-c=/tmp/paho-c/ --enable-samples=yes --enable-static=yes --enable-doc=yes --with-ssl=yes && make && make check; cat test-suite.log; cd -
+  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && ./bootstrap && rm -rf build_autotools/ && mkdir build_autotools/ && cd build_autotools/ && ../configure CXX=$COMPILER --with-paho-mqtt-c=/tmp/paho-c/ --enable-samples=yes --enable-static=yes --enable-doc=no  --with-ssl=no  CPPFLAGS=-DTEST_EXTERNAL_SERVER && make && make check; cat test-suite.log; cd -
+  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && ./bootstrap && rm -rf build_autotools/ && mkdir build_autotools/ && cd build_autotools/ && ../configure CXX=$COMPILER --with-paho-mqtt-c=/tmp/paho-c/ --enable-samples=yes --enable-static=yes --enable-doc=yes --with-ssl=yes CPPFLAGS=-DTEST_EXTERNAL_SERVER && make && make check; cat test-suite.log; cd -
   # Static Analysis
   - cppcheck --enable=all --std=c++11 --force --quiet src/*.cpp
 

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -61,6 +61,10 @@ ifdef COVERAGE
   LDFLAGS += -fprofile-arcs -pg -lgcov
 endif
 
+ifdef TEST_EXTERNAL_SERVER
+  CPPFLAGS += -DTEST_EXTERNAL_SERVER
+endif
+
 LDLIBS += -L$(PAHO_CPP_LIB_DIR) -lpaho-mqttpp3
 LDLIBS += -L$(PAHO_C_LIB_DIR) -l$(PAHO_C_LIB)
 LDLIBS += -lcppunit -ldl


### PR DESCRIPTION
This PR makes the Travis script compile the unit tests with TEXT_EXTERNAL_SERVER definition. 