### PR TITLE
Add AppVeyor - continuous integration for MS-Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,39 @@
+version: 1.1.{build}
+image: Visual Studio 2015
+configuration: Debug
+install:
+- cmd: >-
+    git clone https://github.com/eclipse/paho.mqtt.c.git
+
+    cd paho.mqtt.c
+
+    git checkout -t origin/develop
+
+    mkdir build_cmake
+
+    cd build_cmake
+
+    "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
+
+    cmake -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="C:\Temp\paho-c" -DPAHO_WITH_SSL=TRUE -DPAHO_BUILD_DOCUMENTATION=FALSE -DPAHO_BUILD_SAMPLES=FALSE -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=FALSE ..
+
+    nmake install
+
+    cd ..\..
+
+build_script:
+- cmd: >-
+    mkdir build_cmake
+
+    cd build_cmake
+
+    "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
+
+    cmake -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="C:\Temp\paho-cpp" -DPAHO_MQTT_C_PATH="C:\Temp\paho-c" -DPAHO_WITH_SSL=TRUE -DPAHO_BUILD_DOCUMENTATION=FALSE -DCMAKE_BUILD_TYPE=Release -DCMAKE_VERBOSE_MAKEFILE=TRUE ..
+
+    nmake
+
+    nmake install
+
+    cd ..
+


### PR DESCRIPTION
This PR adds the [AppVeyor ](https://ci.appveyor.com), a continuous integration tool to test the build into Visual Studio. AppVeyor works like Travis but aims at Microsoft Windows. Indeed, this is a port from the Paho MQTT C, which already uses this tool to test their Windows build.

This version builds Paho MQTT C++ using CMake and Visual Studio 14.0 (2015).
