### PR TITLE
Automatically detect if the SSL support is available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,7 +141,7 @@ matrix:
 
 script:
   # Test Makefile building
-  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && make CXX=$COMPILER VERBOSE=1 && sudo make install && make CXX=$COMPILER VERBOSE=1 check
+  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && make CXX=$COMPILER VERBOSE=1 PAHO_C_LIB_DIR=/tmp/paho-c-with-ssl/lib && sudo make install && make CXX=$COMPILER VERBOSE=1 PAHO_C_LIB_DIR=/tmp/paho-c-with-ssl/lib check
   - make clean && sudo make uninstall && pushd test/unit && make clean && popd
   - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && make CXX=$COMPILER VERBOSE=1 SSL=0 && sudo make install && make CXX=$COMPILER VERBOSE=1 SSL=0 check
   - make clean && sudo make uninstall && pushd test/unit && make clean && popd
@@ -149,8 +149,8 @@ script:
   - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && rm -rf build_cmake && mkdir build_cmake && pushd build_cmake && cmake -DCMAKE_CXX_COMPILER=$COMPILER -DPAHO_BUILD_SAMPLES=ON -DPAHO_BUILD_STATIC=ON -DPAHO_BUILD_DOCUMENTATION=OFF -DPAHO_WITH_SSL=OFF .. && make && sudo make install; popd
   - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && rm -rf build_cmake && mkdir build_cmake && pushd build_cmake && cmake -DCMAKE_CXX_COMPILER=$COMPILER -DPAHO_BUILD_SAMPLES=ON -DPAHO_BUILD_STATIC=ON -DPAHO_BUILD_DOCUMENTATION=ON  -DPAHO_WITH_SSL=ON  .. && make && sudo make install; popd
   # Test Autotools building
-  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && ./bootstrap && rm -rf build_autotools/ && mkdir build_autotools/ && pushd build_autotools/ && ../configure CXX=$COMPILER --enable-samples=yes --enable-static=yes --enable-doc=no  --with-ssl=no  && make && make check; cat test-suite.log; popd
-  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && ./bootstrap && rm -rf build_autotools/ && mkdir build_autotools/ && pushd build_autotools/ && ../configure CXX=$COMPILER --enable-samples=yes --enable-static=yes --enable-doc=yes --with-ssl=yes && make && make check; cat test-suite.log; popd
+  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && ./bootstrap && rm -rf build_autotools/ && mkdir build_autotools/ && pushd build_autotools/ && ../configure CXX=$COMPILER --enable-samples=yes --enable-static=no  --enable-doc=no  && make && make check; cat test-suite.log; popd
+  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && ./bootstrap && rm -rf build_autotools/ && mkdir build_autotools/ && pushd build_autotools/ && ../configure CXX=$COMPILER --enable-samples=yes --enable-static=yes --enable-doc=yes --with-paho-mqtt-c=/tmp/paho-c-with-ssl && make && make check; cat test-suite.log; popd
   # Static Analysis
   - cppcheck --enable=all --std=c++11 --force --quiet src/*.cpp
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -146,8 +146,8 @@ script:
   - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && make CXX=$COMPILER VERBOSE=1 SSL=0 && sudo make install && make CXX=$COMPILER VERBOSE=1 SSL=0 check
   - make clean && sudo make uninstall && pushd test/unit && make clean && popd
   # Test CMake building
-  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && rm -rf build_cmake && mkdir build_cmake && pushd build_cmake && cmake -DCMAKE_CXX_COMPILER=$COMPILER -DPAHO_BUILD_SAMPLES=ON -DPAHO_BUILD_STATIC=ON -DPAHO_BUILD_DOCUMENTATION=OFF -DPAHO_WITH_SSL=OFF .. && make && sudo make install; popd
-  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && rm -rf build_cmake && mkdir build_cmake && pushd build_cmake && cmake -DCMAKE_CXX_COMPILER=$COMPILER -DPAHO_BUILD_SAMPLES=ON -DPAHO_BUILD_STATIC=ON -DPAHO_BUILD_DOCUMENTATION=ON  -DPAHO_WITH_SSL=ON  .. && make && sudo make install; popd
+  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && rm -rf build_cmake && mkdir build_cmake && pushd build_cmake && cmake -DCMAKE_CXX_COMPILER=$COMPILER -DPAHO_BUILD_SAMPLES=ON -DPAHO_BUILD_STATIC=ON -DPAHO_BUILD_DOCUMENTATION=OFF .. && make && sudo make install; popd
+  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && rm -rf build_cmake && mkdir build_cmake && pushd build_cmake && cmake -DCMAKE_CXX_COMPILER=$COMPILER -DPAHO_BUILD_SAMPLES=ON -DPAHO_BUILD_STATIC=ON -DPAHO_BUILD_DOCUMENTATION=ON  -DPAHO_MQTT_C_PATH=/tmp/paho-c-with-ssl .. && make && sudo make install; popd
   # Test Autotools building
   - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && ./bootstrap && rm -rf build_autotools/ && mkdir build_autotools/ && pushd build_autotools/ && ../configure CXX=$COMPILER --enable-samples=yes --enable-static=no  --enable-doc=no  && make && make check; cat test-suite.log; popd
   - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && ./bootstrap && rm -rf build_autotools/ && mkdir build_autotools/ && pushd build_autotools/ && ../configure CXX=$COMPILER --enable-samples=yes --enable-static=yes --enable-doc=yes --with-paho-mqtt-c=/tmp/paho-c-with-ssl && make && make check; cat test-suite.log; popd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,54 @@ set(PAHO_BUILD_SAMPLES FALSE CACHE BOOL "Build sample programs")
 set(PAHO_BUILD_DOCUMENTATION FALSE CACHE BOOL "Create and install the HTML based API documentation (requires Doxygen)")
 set(PAHO_MQTT_C_PATH "" CACHE PATH "Add a path to paho.mqtt.c library and headers")
 set(PAHO_MQTT_C paho-mqtt3a)
-SET(PAHO_WITH_SSL TRUE CACHE BOOL "Flag that defines whether to build ssl-enabled binaries too. ")
+
+## extract Paho MQTT C include directory
+get_filename_component(PAHO_MQTT_C_DEV_INC_DIR ${PAHO_MQTT_C_PATH}/src ABSOLUTE)
+get_filename_component(PAHO_MQTT_C_STD_INC_DIR ${PAHO_MQTT_C_PATH}/include ABSOLUTE)
+set(PAHO_MQTT_C_INC_DIR
+    ${PAHO_MQTT_C_DEV_INC_DIR}
+    ${PAHO_MQTT_C_STD_INC_DIR})
+
+## extract Paho MQTT C library directory
+get_filename_component(PAHO_MQTT_C_DEV_LIB_DIR ${PAHO_MQTT_C_PATH}/build/output ABSOLUTE)
+get_filename_component(PAHO_MQTT_C_STD_LIB_DIR ${PAHO_MQTT_C_PATH}/lib ABSOLUTE)
+get_filename_component(PAHO_MQTT_C_STD64_LIB_DIR ${PAHO_MQTT_C_PATH}/lib64 ABSOLUTE)
+set(PAHO_MQTT_C_LIB_DIR
+    ${PAHO_MQTT_C_DEV_LIB_DIR}
+    ${PAHO_MQTT_C_STD_LIB_DIR}
+    ${PAHO_MQTT_C_STD64_LIB_DIR})
+
+## extract Paho MQTT C binary directory (Windows may place libraries there)
+get_filename_component(PAHO_MQTT_C_BIN_DIR ${PAHO_MQTT_C_PATH}/bin ABSOLUTE)
+
+## try to find the Paho MQTT C library with SSL support
+find_library(PAHO_MQTT_C_LIB
+    NAMES paho-mqtt3as
+          mqtt3as
+    PATHS ${PAHO_MQTT_C_LIB_DIR}
+          ${PAHO_MQTT_C_BIN_DIR})
+
+if(${PAHO_MQTT_C_LIB} STREQUAL "PAHO_MQTT_C_LIB-NOTFOUND")
+    ## try to find the Paho MQTT C library without SSL support
+    find_library(PAHO_MQTT_C_LIB
+        NAMES paho-mqtt3a
+              mqtt
+              paho-mqtt
+              mqtt3
+              paho-mqtt3
+              mqtt3a
+        PATHS ${PAHO_MQTT_C_LIB_DIR}
+              ${PAHO_MQTT_C_BIN_DIR})
+
+    if(${PAHO_MQTT_C_LIB} STREQUAL "PAHO_MQTT_C_LIB-NOTFOUND")
+        message(FATAL_ERROR "Could not find Paho MQTT C library")
+    else()
+        set(PAHO_WITH_SSL FALSE CACHE BOOL "Flag that defines whether to build ssl-enabled binaries too. ")
+    endif()
+else()
+    find_package(OpenSSL REQUIRED)
+    set(PAHO_WITH_SSL TRUE CACHE BOOL "Flag that defines whether to build ssl-enabled binaries too. ")
+endif()
 
 ## build flags
 set(CMAKE_CXX_STANDARD 11)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ PAHO_MQTT_C_PATH | "" | Add a path paho.mqtt.c library and headers
 PAHO_BUILD_STATIC | FALSE | Whether to build the static library
 PAHO_BUILD_DOCUMENTATION | FALSE | Create and install the HTML based API documentation (requires Doxygen)
 PAHO_BUILD_SAMPLES | FALSE | Build sample programs
-PAHO_WITH_SSL | TRUE | Flag that defines whether to build ssl-enabled binaries too
 
 Using these variables CMake can be used to generate your Makefiles. The out-of-source build is the default on CMake. Therefore it is recommended to invoke all build commands inside your chosen build directory.
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ Option | Default Value | Description
  --[en/dis]able-doc | no | Build documentation
  --[en/dis]able-peak-warnings | no | Compile with peak warnings level
  --with-paho-mqtt-c |  | Path to a non-standard Paho MQTT C library
- --with[out]-ssl | with | Build with OpenSSL support
+
+The SSL support is automatically decided based on the Paho MQTT C available.
 
 For example, in order to build only the static library:
 (under the assumption that "$PAHO_DIR" points to the directory which contains the paho.mqtt.c source tree)

--- a/configure.ac
+++ b/configure.ac
@@ -160,30 +160,26 @@ AC_CHECK_HEADER([MQTTAsync.h], , AC_MSG_ERROR([missing paho.mqtt.c headers]))
 
 
 # Add OpenSSL support to build secure PAHO libraries
-AC_ARG_WITH(
-	[ssl],
-	AS_HELP_STRING(
-		[--with-ssl=@<:@yes/no@:>@],
-		[with OpenSSL support @<:@default=no@:>@]
-	),
-	,
-	with_ssl=yes
+AC_SEARCH_LIBS(
+	[MQTTAsync_create],
+	[paho-mqtt3as],
+	[
+		AC_CHECK_HEADER([openssl/crypto.h], , AC_MSG_ERROR([missing openssl/crypto.h header]))
+		AC_CHECK_LIB([crypto], [CRYPTO_num_locks], , AC_MSG_ERROR([missing crypto library]))
+
+		AC_CHECK_HEADER([openssl/ssl.h], , AC_MSG_ERROR([missing openssl/ssl.h header]))
+		AC_CHECK_LIB([ssl], [SSL_connect], , AC_MSG_ERROR([missing ssl library]))
+
+		AC_DEFINE([OPENSSL], [], [OpenSSL support])
+
+		with_ssl=yes
+	],
+	[
+		AC_SEARCH_LIBS([MQTTAsync_connect], [paho-mqtt3a], , AC_MSG_ERROR([missing paho.mqtt.c library]))
+
+		with_ssl=no
+	]
 )
-
-AS_IF([test "x$with_ssl" = "xyes"], [
-	AC_CHECK_HEADER([openssl/crypto.h], , AC_MSG_ERROR([missing openssl/crypto.h header]))
-	AC_CHECK_LIB([crypto], [CRYPTO_num_locks], , AC_MSG_ERROR([missing crypto library]))
-
-	AC_CHECK_HEADER([openssl/ssl.h], , AC_MSG_ERROR([missing openssl/ssl.h header]))
-	AC_CHECK_LIB([ssl], [SSL_connect], , AC_MSG_ERROR([missing ssl library]))
-
-	AC_CHECK_LIB([paho-mqtt3as], [MQTTAsync_create], , AC_MSG_ERROR([missing paho.mqtt.c SSL library]))
-
-	AC_DEFINE([OPENSSL], [], [OpenSSL support])
-],
-[
-	AC_SEARCH_LIBS([MQTTAsync_create], [mqtt paho-mqtt mqtt3 paho-mqtt3 mqtt3a paho-mqtt3a], , AC_MSG_ERROR([missing paho.mqtt.c library]))
-])
 
 AM_CONDITIONAL([PAHO_WITH_SSL], [test "$with_ssl" = yes])
 

--- a/install_paho_mqtt_c.sh
+++ b/install_paho_mqtt_c.sh
@@ -3,14 +3,23 @@
 # Installs the matching version of Paho MQTT C library required by the C++ lib.
 #
 
+# Install Paho MQTT C without SLL support on system directory
 git clone https://github.com/eclipse/paho.mqtt.c.git
 pushd paho.mqtt.c
 git checkout develop
 mkdir build_cmake && cd build_cmake
-cmake -DPAHO_WITH_SSL=ON ..
+cmake -DPAHO_WITH_SSL=OFF ..
 make
 sudo make install
 sudo ldconfig
+popd
+
+# Install Paho MQTT C with SLL support on a temporary directory
+pushd paho.mqtt.c
+mkdir build_cmake_no_ssl && cd build_cmake_no_ssl
+cmake -DCMAKE_INSTALL_PREFIX=/tmp/paho-c-with-ssl -DPAHO_WITH_SSL=ON ..
+make
+make install
 popd
 
 exit 0

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,50 +95,9 @@ if(PAHO_BUILD_STATIC)
         LIBRARY DESTINATION lib)
 endif()
 
-## extract Paho MQTT C include directory
-get_filename_component(PAHO_MQTT_C_DEV_INC_DIR ${PAHO_MQTT_C_PATH}/src ABSOLUTE)
-get_filename_component(PAHO_MQTT_C_STD_INC_DIR ${PAHO_MQTT_C_PATH}/include ABSOLUTE)
-set(PAHO_MQTT_C_INC_DIR
-    ${PAHO_MQTT_C_DEV_INC_DIR}
-    ${PAHO_MQTT_C_STD_INC_DIR})
-
-## extract Paho MQTT C library directory
-get_filename_component(PAHO_MQTT_C_DEV_LIB_DIR ${PAHO_MQTT_C_PATH}/build/output ABSOLUTE)
-get_filename_component(PAHO_MQTT_C_STD_LIB_DIR ${PAHO_MQTT_C_PATH}/lib ABSOLUTE)
-get_filename_component(PAHO_MQTT_C_STD64_LIB_DIR ${PAHO_MQTT_C_PATH}/lib64 ABSOLUTE)
-set(PAHO_MQTT_C_LIB_DIR
-    ${PAHO_MQTT_C_DEV_LIB_DIR}
-    ${PAHO_MQTT_C_STD_LIB_DIR}
-    ${PAHO_MQTT_C_STD64_LIB_DIR})
-
-## extract Paho MQTT C binary directory (Windows may place libraries there)
-get_filename_component(PAHO_MQTT_C_BIN_DIR ${PAHO_MQTT_C_PATH}/bin ABSOLUTE)
-
 ## add library suffixes so Windows can find Paho DLLs
 set(CMAKE_FIND_LIBRARY_PREFIXES ${CMAKE_FIND_LIBRARY_PREFIXES} "")
 set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} ".dll" ".lib")
-
-if(PAHO_WITH_SSL)
-    ## find the Paho MQTT C SSL library
-    find_library(PAHO_MQTT_C_LIB
-        NAMES paho-mqtt3as
-              mqtt3as
-        PATHS ${PAHO_MQTT_C_LIB_DIR}
-              ${PAHO_MQTT_C_BIN_DIR})
-
-    find_package(OpenSSL REQUIRED)
-else()
-    ## find the Paho MQTT C library
-    find_library(PAHO_MQTT_C_LIB
-        NAMES paho-mqtt3a
-              mqtt
-              paho-mqtt
-              mqtt3
-              paho-mqtt3
-              mqtt3a
-        PATHS ${PAHO_MQTT_C_LIB_DIR}
-              ${PAHO_MQTT_C_BIN_DIR})
-endif()
 
 ## use the Paho MQTT C library if found. Otherwise terminate the compilation
 if(${PAHO_MQTT_C_LIB} STREQUAL "PAHO_MQTT_C_LIB-NOTFOUND")


### PR DESCRIPTION
Autotools: remove the `--with(out)-ssl` argument. The Autotools no longer rely on the user to decide whether or not to enable the SSL support. Now the decision depends on whether there is a Paho MQTT C library with support for SSL.

CMake: remove the `PAHO_WITH_SSL` option. Like Autotools, CMake detects and choose the SSL support based on the Paho MQTT C available.

This PR enables the SSL if there is a Paho MQTT C available with support for SSL. Otherwise, if there is only a Paho MQTT C library without SSL support, it disables the SSL support. The rationale behind the automatic decision is because the user already decided about SSL support when he built the Paho MQTT C.

Also, it changes the Paho MQTT C installation through Travis. It installs the version without SSL in the system directory (e.g. `/usr/local`.) Otherwise, the SSL-enabled Paho MQTT C is always used once the system directories have precedence over the Autotools' `--with-paho-mqtt-c` argument and the CMake's `PAHO_WITH_SSL` argument.

