### PR TITLE
Add support for CodeCov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,28 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+  branch: develop
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "header, diff"
+  behavior: default
+  require_changes: no
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,14 @@ matrix:
       env: COMPILER=g++-4.9
     # GCC 5
     - compiler: gcc
+      before_install:
+        - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/${COMPILER} 50
+        - sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/${COVERAGE} 50
+        - ./travis_install_lcov.sh
+        # gcc version MUST match gcov version
+        - g++ --version
+        - gcov --version
+        - lcov --version
       addons:
         apt:
           sources:
@@ -79,7 +87,11 @@ matrix:
             - cmake-data
             - doxygen
             - mosquitto
-      env: COMPILER=g++-5
+      after_success:
+        - ./travis_execute_lcov.sh
+      env:
+        - COMPILER=g++-5
+        - COVERAGE=gcov-5
     # GCC 6
     - compiler: gcc
       addons:
@@ -141,9 +153,9 @@ matrix:
 
 script:
   # Test Makefile building
-  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && make CXX=$COMPILER VERBOSE=1 && sudo make install && make CXX=$COMPILER VERBOSE=1 check
+  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && make CXX=$COMPILER VERBOSE=1 && sudo make install && make CXX=$COMPILER VERBOSE=1 COVERAGE=1 check
   - make clean && sudo make uninstall && pushd test/unit && make clean && popd
-  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && make CXX=$COMPILER VERBOSE=1 SSL=0 && sudo make install && make CXX=$COMPILER VERBOSE=1 SSL=0 check
+  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && make CXX=$COMPILER VERBOSE=1 SSL=0 && sudo make install && make CXX=$COMPILER VERBOSE=1 SSL=0 COVERAGE=1 check
   - make clean && sudo make uninstall && pushd test/unit && make clean && popd
   # Test CMake building
   - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && rm -rf build_cmake && mkdir build_cmake && pushd build_cmake && cmake -DCMAKE_CXX_COMPILER=$COMPILER -DPAHO_BUILD_SAMPLES=ON -DPAHO_BUILD_STATIC=ON -DPAHO_BUILD_DOCUMENTATION=OFF -DPAHO_WITH_SSL=OFF .. && make && sudo make install; popd

--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,10 @@ LDFLAGS := -g -shared -Wl,-soname,$(LIB_MAJOR_LINK) -L$(LIB_DIR)
 LDFLAGS += -L$(PAHO_C_LIB_DIR)
 
 ifdef COVERAGE
-  CXXFLAGS += -fprofile-arcs -ftest-coverage
-  LDFLAGS += -fprofile-arcs -pg -lgcov
+  # Disable coverage for clang due the segmentation fault caused by
+  # the Bug 20530 [https://bugs.llvm.org//show_bug.cgi?id=20530]
+  CXXFLAGS += $(if $(findstring clang++,$(CXX)), , -fprofile-arcs -ftest-coverage)
+  LDFLAGS += $(if $(findstring clang++,$(CXX)), , -fprofile-arcs -pg -lgcov)
 endif
 
 # ----- C++ Dependencies -----

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -58,8 +58,10 @@ else
 endif
 
 ifdef COVERAGE
-  CXXFLAGS += -fprofile-arcs -ftest-coverage
-  LDFLAGS += -fprofile-arcs -pg -lgcov
+  # Disable coverage for clang due the segmentation fault caused by
+  # the Bug 20530 [https://bugs.llvm.org//show_bug.cgi?id=20530]
+  CXXFLAGS += $(if $(findstring clang++,$(CXX)), , -fprofile-arcs -ftest-coverage)
+  LDFLAGS += $(if $(findstring clang++,$(CXX)), , -fprofile-arcs -pg -lgcov)
 endif
 
 LDLIBS += -L$(PAHO_CPP_LIB_DIR) -lpaho-mqttpp3

--- a/travis_execute_lcov.sh
+++ b/travis_execute_lcov.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Execute lcov.
+#
+
+# Creating report
+cd ${TRAVIS_BUILD_DIR}
+lcov --directory obj/ --base-directory ./ --capture --output-file coverage.info
+lcov --list coverage.info
+
+# Uploading report to CodeCov
+bash <(curl -s https://codecov.io/bash) -t 87eab1ad-9a4e-4385-a498-70fe89c01020 || echo "Codecov did not collect coverage reports"
+
+exit 0
+

--- a/travis_install_lcov.sh
+++ b/travis_install_lcov.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# Installs lcov.
+#
+
+cd ${TRAVIS_BUILD_DIR}
+wget http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.13.orig.tar.gz
+tar xf lcov_1.13.orig.tar.gz
+pushd lcov-1.13/
+sudo make install
+popd
+
+exit 0
+


### PR DESCRIPTION
This PR provides automatic code coverage execution. One can check the current Paho MQTT C++ code coverage [here ](https://codecov.io).