### PR TITLE
Add code coverage to Autotools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,8 +149,8 @@ script:
   - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && rm -rf build_cmake && mkdir build_cmake && pushd build_cmake && cmake -DCMAKE_CXX_COMPILER=$COMPILER -DPAHO_BUILD_SAMPLES=ON -DPAHO_BUILD_STATIC=ON -DPAHO_BUILD_DOCUMENTATION=OFF -DPAHO_WITH_SSL=OFF .. && make && sudo make install; popd
   - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && rm -rf build_cmake && mkdir build_cmake && pushd build_cmake && cmake -DCMAKE_CXX_COMPILER=$COMPILER -DPAHO_BUILD_SAMPLES=ON -DPAHO_BUILD_STATIC=ON -DPAHO_BUILD_DOCUMENTATION=ON  -DPAHO_WITH_SSL=ON  .. && make && sudo make install; popd
   # Test Autotools building
-  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && ./bootstrap && rm -rf build_autotools/ && mkdir build_autotools/ && pushd build_autotools/ && ../configure CXX=$COMPILER --enable-samples=yes --enable-static=yes --enable-doc=no  --with-ssl=no  && make && make check; cat test-suite.log; popd
-  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && ./bootstrap && rm -rf build_autotools/ && mkdir build_autotools/ && pushd build_autotools/ && ../configure CXX=$COMPILER --enable-samples=yes --enable-static=yes --enable-doc=yes --with-ssl=yes && make && make check; cat test-suite.log; popd
+  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && ./bootstrap && rm -rf build_autotools/ && mkdir build_autotools/ && pushd build_autotools/ && ../configure CXX=$COMPILER --enable-samples=yes --enable-static=yes --enable-doc=no  --enable-coverage=no  --with-ssl=no  && make && make check; cat test-suite.log; popd
+  - if [ "$COMPILER" == "" ]; then COMPILER=g++; fi && ./bootstrap && rm -rf build_autotools/ && mkdir build_autotools/ && pushd build_autotools/ && ../configure CXX=$COMPILER --enable-samples=yes --enable-static=yes --enable-doc=yes --enable-coverage=yes --with-ssl=yes && make && make check; cat test-suite.log; popd
   # Static Analysis
   - cppcheck --enable=all --std=c++11 --force --quiet src/*.cpp
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Option | Default Value | Description
  --[en/dis]able-samples | no | Build sample programs
  --[en/dis]able-doc | no | Build documentation
  --[en/dis]able-peak-warnings | no | Compile with peak warnings level
+ --[en/dis]able-coverage | no | Extra code to measure code coverage
  --with-paho-mqtt-c |  | Path to a non-standard Paho MQTT C library
  --with[out]-ssl | with | Build with OpenSSL support
 

--- a/configure.ac
+++ b/configure.ac
@@ -143,6 +143,23 @@ AS_IF([test "x$enable_peak_warnings" = "xyes"], [
 ])
 
 
+# Code coverage
+AC_ARG_ENABLE(
+	[coverage],
+	AS_HELP_STRING(
+		[--enable-coverage=@<:@yes/no@:>@],
+		[enable code coverage @<:@default=no@:>@]
+	),
+	,
+	enable_coverage=no
+)
+
+AS_IF([test "x$enable_coverage" = "xyes"], [
+	CXXFLAGS="$CXXFLAGS -fprofile-arcs -ftest-coverage"
+	LDFLAGS="$LDFLAGS -fprofile-arcs -pg -lgcov"
+])
+
+
 # Add Paho MQTT C path
 AC_ARG_WITH(
 	[paho-mqtt-c],
@@ -209,6 +226,7 @@ echo "            Build as static library : $enable_static"
 echo "                      Build samples : $enable_samples"
 echo "                Build documentation : $enable_doc"
 echo "          Enable peak warning level : $enable_peak_warnings"
+echo "               Enable code coverage : $enable_coverage"
 echo "                   With Paho MQTT C : $with_paho_mqtt_c"
 echo "               With OpenSSL library : $with_ssl"
 echo "                      With CPPFLAGS : $CPPFLAGS"


### PR DESCRIPTION
Add the `--enable-coverage` option to configure script. This option adds code coverage flags to the Autotools build.