### PR TITLE
Isolate the CMake code that detects the Paho MQTT C library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ project("paho-mqtt-cpp" LANGUAGES CXX)
 ## library name
 set(PAHO_MQTT_CPP paho-mqttpp3)
 
+## build modules
+set(CMAKE_SCRIPTS "${CMAKE_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
+
 ## build settings
 set(PAHO_VERSION_MAJOR 0)
 set(PAHO_VERSION_MINOR 9)
@@ -43,10 +47,20 @@ set(PAHO_MQTT_C_PATH "" CACHE PATH "Add a path to paho.mqtt.c library and header
 set(PAHO_MQTT_C paho-mqtt3a)
 SET(PAHO_WITH_SSL TRUE CACHE BOOL "Flag that defines whether to build ssl-enabled binaries too. ")
 
+include(CMakePahoMqttC)
+
 ## build flags
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+## Paho MQTT C++ include directory
+get_filename_component(PAHO_MQTT_CPP_INC_DIR ${CMAKE_SOURCE_DIR}/src ABSOLUTE)
+include_directories(${PAHO_MQTT_CPP_INC_DIR})
+
+## Paho MQTT C++ library directory
+get_filename_component(PAHO_MQTT_CPP_LIB_DIR ${CMAKE_BINARY_DIR}/src ABSOLUTE)
+link_directories(${PAHO_MQTT_CPP_LIB_DIR})
 
 ## build directories
 

--- a/cmake/modules/CMakePahoMqttC.cmake
+++ b/cmake/modules/CMakePahoMqttC.cmake
@@ -1,0 +1,64 @@
+#*******************************************************************************
+#  Copyright (c) 2016-2017 Guilherme M. Ferreira <guilherme.maciel.ferreira@gmail.com>
+#
+#  All rights reserved. This program and the accompanying materials
+#  are made available under the terms of the Eclipse Public License v1.0
+#  and Eclipse Distribution License v1.0 which accompany this distribution.
+#
+#  The Eclipse Public License is available at
+#     http://www.eclipse.org/legal/epl-v10.html
+#  and the Eclipse Distribution License is available at
+#    http://www.eclipse.org/org/documents/edl-v10.php.
+#
+#  Contributors:
+#     Guilherme Maciel Ferreira - initial version
+#*******************************************************************************/
+
+## Paho MQTT C include directory
+get_filename_component(PAHO_MQTT_C_DEV_INC_DIR ${PAHO_MQTT_C_PATH}/src ABSOLUTE)
+get_filename_component(PAHO_MQTT_C_STD_INC_DIR ${PAHO_MQTT_C_PATH}/include ABSOLUTE)
+set(PAHO_MQTT_C_INC_DIR
+    ${PAHO_MQTT_C_DEV_INC_DIR}
+    ${PAHO_MQTT_C_STD_INC_DIR})
+
+## Paho MQTT C library directory
+get_filename_component(PAHO_MQTT_C_DEV_LIB_DIR ${PAHO_MQTT_C_PATH}/build/output ABSOLUTE)
+get_filename_component(PAHO_MQTT_C_STD_LIB_DIR ${PAHO_MQTT_C_PATH}/lib ABSOLUTE)
+get_filename_component(PAHO_MQTT_C_STD64_LIB_DIR ${PAHO_MQTT_C_PATH}/lib64 ABSOLUTE)
+set(PAHO_MQTT_C_LIB_DIR
+    ${PAHO_MQTT_C_DEV_LIB_DIR}
+    ${PAHO_MQTT_C_STD_LIB_DIR}
+    ${PAHO_MQTT_C_STD64_LIB_DIR})
+
+## Paho MQTT C binary directory (Windows may place libraries there)
+get_filename_component(PAHO_MQTT_C_BIN_DIR ${PAHO_MQTT_C_PATH}/bin ABSOLUTE)
+
+if(PAHO_WITH_SSL)
+    ## find the Paho MQTT C SSL library
+    find_library(PAHO_MQTT_C_LIB
+        NAMES paho-mqtt3as
+              mqtt3as
+        PATHS ${PAHO_MQTT_C_LIB_DIR}
+              ${PAHO_MQTT_C_BIN_DIR})
+
+    find_package(OpenSSL REQUIRED)
+else()
+    ## find the Paho MQTT C library
+    find_library(PAHO_MQTT_C_LIB
+        NAMES paho-mqtt3a
+              mqtt3a
+        PATHS ${PAHO_MQTT_C_LIB_DIR}
+              ${PAHO_MQTT_C_BIN_DIR})
+endif()
+
+## use the Paho MQTT C library if found. Otherwise terminate the compilation
+if(${PAHO_MQTT_C_LIB} STREQUAL "PAHO_MQTT_C_LIB-NOTFOUND")
+    message(FATAL_ERROR "Could not find Paho MQTT C library")
+else()
+    ## include directories
+    include_directories(${PAHO_MQTT_C_INC_DIR})
+
+    ## link directories
+    link_directories(${PAHO_MQTT_C_LIB_DIR})
+    link_directories(${PAHO_MQTT_C_BIN_DIR})
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,7 +66,8 @@ add_library(${PAHO_MQTT_CPP} SHARED
 
 ## add dependencies to the shared library
 target_link_libraries(${PAHO_MQTT_CPP}
-    ${LIBS_SYSTEM})
+    ${LIBS_SYSTEM}
+    ${PAHO_MQTT_C_LIB})
 
 ## set the shared library soname
 set_target_properties(${PAHO_MQTT_CPP} PROPERTIES
@@ -87,7 +88,8 @@ if(PAHO_BUILD_STATIC)
 
     ## add dependencies to the static library
     target_link_libraries(${PAHO_MQTT_CPP}-static
-        ${LIBS_SYSTEM})
+        ${LIBS_SYSTEM}
+        ${PAHO_MQTT_C_LIB})
 
     ## install the static library
     install(TARGETS ${PAHO_MQTT_CPP}-static
@@ -95,57 +97,6 @@ if(PAHO_BUILD_STATIC)
         LIBRARY DESTINATION lib)
 endif()
 
-## extract Paho MQTT C include directory
-get_filename_component(PAHO_MQTT_C_DEV_INC_DIR ${PAHO_MQTT_C_PATH}/src ABSOLUTE)
-get_filename_component(PAHO_MQTT_C_STD_INC_DIR ${PAHO_MQTT_C_PATH}/include ABSOLUTE)
-set(PAHO_MQTT_C_INC_DIR
-    ${PAHO_MQTT_C_DEV_INC_DIR}
-    ${PAHO_MQTT_C_STD_INC_DIR})
-
-## extract Paho MQTT C library directory
-get_filename_component(PAHO_MQTT_C_DEV_LIB_DIR ${PAHO_MQTT_C_PATH}/build/output ABSOLUTE)
-get_filename_component(PAHO_MQTT_C_STD_LIB_DIR ${PAHO_MQTT_C_PATH}/lib ABSOLUTE)
-get_filename_component(PAHO_MQTT_C_STD64_LIB_DIR ${PAHO_MQTT_C_PATH}/lib64 ABSOLUTE)
-set(PAHO_MQTT_C_LIB_DIR
-    ${PAHO_MQTT_C_DEV_LIB_DIR}
-    ${PAHO_MQTT_C_STD_LIB_DIR}
-    ${PAHO_MQTT_C_STD64_LIB_DIR})
-
-## extract Paho MQTT C binary directory (Windows may place libraries there)
-get_filename_component(PAHO_MQTT_C_BIN_DIR ${PAHO_MQTT_C_PATH}/bin ABSOLUTE)
-
 ## add library suffixes so Windows can find Paho DLLs
 set(CMAKE_FIND_LIBRARY_PREFIXES ${CMAKE_FIND_LIBRARY_PREFIXES} "")
 set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES} ".dll" ".lib")
-
-if(PAHO_WITH_SSL)
-    ## find the Paho MQTT C SSL library
-    find_library(PAHO_MQTT_C_LIB
-        NAMES paho-mqtt3as
-              mqtt3as
-        PATHS ${PAHO_MQTT_C_LIB_DIR}
-              ${PAHO_MQTT_C_BIN_DIR})
-
-    find_package(OpenSSL REQUIRED)
-else()
-    ## find the Paho MQTT C library
-    find_library(PAHO_MQTT_C_LIB
-        NAMES paho-mqtt3a
-              mqtt
-              paho-mqtt
-              mqtt3
-              paho-mqtt3
-              mqtt3a
-        PATHS ${PAHO_MQTT_C_LIB_DIR}
-              ${PAHO_MQTT_C_BIN_DIR})
-endif()
-
-## use the Paho MQTT C library if found. Otherwise terminate the compilation
-if(${PAHO_MQTT_C_LIB} STREQUAL "PAHO_MQTT_C_LIB-NOTFOUND")
-    message(FATAL_ERROR "Could not find Paho MQTT C library")
-else()
-    include_directories(${PAHO_MQTT_C_INC_DIR})
-    link_directories(${PAHO_MQTT_C_LIB_DIR})
-    target_link_libraries(${PAHO_MQTT_CPP}
-        ${PAHO_MQTT_C_LIB})
-endif()

--- a/src/samples/CMakeLists.txt
+++ b/src/samples/CMakeLists.txt
@@ -16,30 +16,8 @@
 
 ## Note: on OS X you should install XCode and the associated command-line tools
 
-## Paho MQTT C include directory
-get_filename_component(PAHO_MQTT_C_DEV_INC_DIR ${PAHO_MQTT_C_PATH}/src ABSOLUTE)
-get_filename_component(PAHO_MQTT_C_STD_INC_DIR ${PAHO_MQTT_C_PATH}/include ABSOLUTE)
-set(PAHO_MQTT_C_INC_DIR
-    ${PAHO_MQTT_C_DEV_INC_DIR}
-    ${PAHO_MQTT_C_STD_INC_DIR})
-
-## Paho MQTT C++ include directory
-get_filename_component(PAHO_MQTT_CPP_INC_DIR ${CMAKE_SOURCE_DIR}/src ABSOLUTE)
-
 ## include directories
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-include_directories(${PAHO_MQTT_C_INC_DIR})
-include_directories(${PAHO_MQTT_CPP_INC_DIR})
-
-## Paho MQTT C library directory
-get_filename_component(PAHO_MQTT_C_LIB_DIR ${PAHO_MQTT_C_LIB} DIRECTORY)
-
-## Paho MQTT C++ library directory
-get_filename_component(PAHO_MQTT_CPP_LIB_DIR ${CMAKE_BINARY_DIR}/src ABSOLUTE)
-
-## link directories
-link_directories(${PAHO_MQTT_C_LIB_DIR})
-link_directories(${PAHO_MQTT_CPP_LIB_DIR})
 
 ## binary files
 add_executable(async_publish async_publish.cpp)


### PR DESCRIPTION
Isolates the Paho MQTT C specific building stuff. It does not pollute other `CMakeLists.txt` and provides better reuse and less duplication.