### PR TITLE
Fix the tests

### DIFF
--- a/src/async_client.cpp
+++ b/src/async_client.cpp
@@ -56,10 +56,14 @@ async_client::async_client(const string& serverURI, const string& clientId,
 		opts->maxBufferedMessages = maxBufferedMessages;
 	}
 
-	MQTTAsync_createWithOptions(&cli_, serverURI.c_str(), clientId.c_str(),
+	auto rc = MQTTAsync_createWithOptions(&cli_, serverURI.c_str(), clientId.c_str(),
 								MQTTCLIENT_PERSISTENCE_DEFAULT,
 								const_cast<char*>(persistDir.c_str()),
 								opts.get());
+
+	if (rc != 0) {
+		throw exception(rc);
+	}
 }
 
 async_client::async_client(const string& serverURI, const string& clientId,

--- a/src/mqtt/async_client.h
+++ b/src/mqtt/async_client.h
@@ -122,6 +122,7 @@ public:
 	 * @param clientId a client identifier that is unique on the server
 	 *  			   being connected to
 	 * @param persistDir The directory to use for persistence data
+	 * @throw exception if an argument is invalid
 	 */
 	async_client(const string& serverURI, const string& clientId,
 				 const string& persistDir);
@@ -136,6 +137,7 @@ public:
 	 *  			   being connected to
 	 * @param persistence The user persistence structure. If this is null,
 	 *  				  then no persistence is used.
+	 * @throw exception if an argument is invalid
 	 */
 	async_client(const string& serverURI, const string& clientId,
 				 iclient_persistence* persistence=nullptr);
@@ -150,6 +152,7 @@ public:
 	 * @param maxBufferedMessages the maximum number of messages allowed to
 	 *  						  be buffered while not connected
 	 * @param persistDir The directory to use for persistence data
+	 * @throw exception if an argument is invalid
 	 */
 	async_client(const string& serverURI, const string& clientId,
 				 int maxBufferedMessages, const string& persistDir);
@@ -166,6 +169,7 @@ public:
 	 *  						  be buffered while not connected
 	 * @param persistence The user persistence structure. If this is null,
 	 *  				  then no persistence is used.
+	 * @throw exception if an argument is invalid
 	 */
 	async_client(const string& serverURI, const string& clientId,
 				 int maxBufferedMessages, iclient_persistence* persistence=nullptr);

--- a/test/unit/async_client_test.h
+++ b/test/unit/async_client_test.h
@@ -128,6 +128,16 @@ public:
 		CPPUNIT_ASSERT_EQUAL(CLIENT_ID, cli.get_client_id());
 	}
 
+	void test_user_constructor_2_string_args_failure() {
+		int reason_code = MQTTASYNC_SUCCESS;
+		try {
+			mqtt::async_client cli { BAD_SERVER_URI, CLIENT_ID };
+		} catch (mqtt::exception& ex) {
+			reason_code = ex.get_reason_code();
+		}
+		CPPUNIT_ASSERT_EQUAL(MQTTASYNC_BAD_PROTOCOL, reason_code);
+	}
+
 	void test_user_constructor_3_string_args() {
 		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID, PERSISTENCE_DIR };
 
@@ -179,7 +189,7 @@ public:
 	}
 
 	void test_connect_1_arg_failure() {
-		mqtt::async_client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		mqtt::token_ptr token_conn { nullptr };
@@ -228,7 +238,7 @@ public:
 	}
 
 	void test_connect_3_args_failure() {
-		mqtt::async_client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		mqtt::token_ptr token_conn { nullptr };
@@ -288,7 +298,7 @@ public:
 	}
 
 	void test_disconnect_1_arg_failure() {
-		mqtt::async_client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		mqtt::token_ptr token_disconn { nullptr };
@@ -339,7 +349,7 @@ public:
 	}
 
 	void test_disconnect_3_args_failure() {
-		mqtt::async_client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		mqtt::token_ptr token_disconn { nullptr };
@@ -495,7 +505,7 @@ public:
 	}
 
 	void test_publish_2_args_failure() {
-		mqtt::async_client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		int reason_code = MQTTASYNC_SUCCESS;
@@ -534,7 +544,7 @@ public:
 	}
 
 	void test_publish_4_args_failure() {
-		mqtt::async_client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		int reason_code = MQTTASYNC_SUCCESS;
@@ -633,7 +643,7 @@ public:
 	}
 
 	void test_subscribe_single_topic_2_args_failure() {
-		mqtt::async_client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		int reason_code = MQTTASYNC_SUCCESS;
@@ -670,7 +680,7 @@ public:
 	}
 
 	void test_subscribe_single_topic_4_args_failure() {
-		mqtt::async_client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		int reason_code = MQTTASYNC_SUCCESS;
@@ -705,7 +715,7 @@ public:
 	}
 
 	void test_subscribe_many_topics_2_args_failure() {
-		mqtt::async_client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		try {
@@ -751,7 +761,7 @@ public:
 	}
 
 	void test_subscribe_many_topics_4_args_failure() {
-		mqtt::async_client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		mqtt::test::dummy_action_listener listener;
@@ -799,7 +809,7 @@ public:
 	}
 
 	void test_unsubscribe_single_topic_1_arg_failure() {
-		mqtt::async_client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		int reason_code = MQTTASYNC_SUCCESS;
@@ -836,7 +846,7 @@ public:
 	}
 
 	void test_unsubscribe_single_topic_3_args_failure() {
-		mqtt::async_client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		int reason_code = MQTTASYNC_SUCCESS;
@@ -872,7 +882,7 @@ public:
 	}
 
 	void test_unsubscribe_many_topics_1_arg_failure() {
-		mqtt::async_client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		int reason_code = MQTTASYNC_SUCCESS;
@@ -909,7 +919,7 @@ public:
 	}
 
 	void test_unsubscribe_many_topics_3_args_failure() {
-		mqtt::async_client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::async_client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		mqtt::test::dummy_action_listener listener;

--- a/test/unit/client_test.h
+++ b/test/unit/client_test.h
@@ -117,6 +117,16 @@ public:
 		CPPUNIT_ASSERT_EQUAL(CLIENT_ID, cli.get_client_id());
 	}
 
+	void test_user_constructor_2_string_args_failure() {
+		int reason_code = MQTTASYNC_SUCCESS;
+		try {
+			mqtt::client cli { BAD_SERVER_URI, CLIENT_ID };
+		} catch (mqtt::exception& ex) {
+			reason_code = ex.get_reason_code();
+		}
+		CPPUNIT_ASSERT_EQUAL(MQTTASYNC_BAD_PROTOCOL, reason_code);
+	}
+
 	void test_user_constructor_3_string_args() {
 		mqtt::client cli { GOOD_SERVER_URI, CLIENT_ID, PERSISTENCE_DIR };
 
@@ -159,7 +169,7 @@ public:
 	}
 
 	void test_connect_1_arg_failure() {
-		mqtt::client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		mqtt::connect_options co;
@@ -203,7 +213,7 @@ public:
 	}
 
 	void test_disconnect_1_arg_failure() {
-		mqtt::client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		int reason_code = MQTTASYNC_SUCCESS;
@@ -282,7 +292,7 @@ public:
 	}
 
 	void test_publish_pointer_2_args_failure() {
-		mqtt::client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		int reason_code = MQTTASYNC_SUCCESS;
@@ -354,7 +364,7 @@ public:
 	}
 
 	void test_subscribe_single_topic_1_arg_failure() {
-		mqtt::client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		int reason_code = MQTTASYNC_SUCCESS;
@@ -380,7 +390,7 @@ public:
 	}
 
 	void test_subscribe_single_topic_2_args_failure() {
-		mqtt::client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		int reason_code = MQTTASYNC_SUCCESS;
@@ -406,7 +416,7 @@ public:
 	}
 
 	void test_subscribe_many_topics_1_arg_failure() {
-		mqtt::client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		int reason_code = MQTTASYNC_SUCCESS;
@@ -432,7 +442,7 @@ public:
 	}
 
 	void test_subscribe_many_topics_2_args_failure() {
-		mqtt::client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		try {
@@ -466,7 +476,7 @@ public:
 	}
 
 	void test_unsubscribe_single_topic_1_arg_failure() {
-		mqtt::client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		int reason_code = MQTTASYNC_SUCCESS;
@@ -492,7 +502,7 @@ public:
 	}
 
 	void test_unsubscribe_many_topics_1_arg_failure() {
-		mqtt::client cli { BAD_SERVER_URI, CLIENT_ID };
+		mqtt::client cli { GOOD_SERVER_URI, CLIENT_ID };
 		CPPUNIT_ASSERT_EQUAL(false, cli.is_connected());
 
 		int reason_code = MQTTASYNC_SUCCESS;


### PR DESCRIPTION
There were 2 problems:

1. The C++ library was expecting that a C client can always be created even when given invalid arguments, which is not the case, leading to a segfault when trying to use a C++ client created with invalid arguments. This is fixed by throwing early.
2. The support for absolute paths in persistence directory is currently broken in the C library. This is worked around by using a relative path.