### PR TITLE
Allow for usage in C++17 code.

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -24,7 +24,6 @@
 namespace mqtt {
 
 const std::chrono::minutes client::DFLT_TIMEOUT = std::chrono::minutes(5);
-constexpr int client::DFLT_QOS;
 
 /////////////////////////////////////////////////////////////////////////////
 

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -25,9 +25,6 @@ namespace mqtt {
 
 /////////////////////////////////////////////////////////////////////////////
 
-constexpr int message::DFLT_QOS;
-constexpr bool message::DFLT_RETAINED;
-
 const MQTTAsync_message message::DFLT_C_STRUCT = MQTTAsync_message_initializer;
 
 const string message::EMPTY_STR;


### PR DESCRIPTION
From: https://en.cppreference.com/w/cpp/language/static

If a static data member is declared constexpr,
it is implicitly inline and does not need to be
redeclared at namespace scope. This redeclaration
without an initializer (formerly required)
is still permitted, but is deprecated.