### PR TITLE
Add TLS option support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build/
 lib/
 obj/
 \.hg/

--- a/src/mqtt/ssl_options.h
+++ b/src/mqtt/ssl_options.h
@@ -67,6 +67,14 @@ class ssl_options
 	 */
 	string enabledCipherSuites_;
 
+	/** 
+	 * The SSL/TLS version to use. Specify one of MQTT_SSL_VERSION_DEFAULT (0),
+	 * MQTT_SSL_VERSION_TLS_1_0 (1), MQTT_SSL_VERSION_TLS_1_1 (2) or 
+	 * MQTT_SSL_VERSION_TLS_1_2 (3).
+	 * Only used if struct_version is >= 1.
+	 */
+	int sslVersion_;
+
 	/** The connect options has special access */
 	friend class connect_options;
 	friend class connect_options_test;
@@ -116,7 +124,8 @@ public:
 	 */
 	ssl_options(const string& trustStore, const string& keyStore,
 				const string& privateKey, const string& privateKeyPassword,
-				const string& enabledCipherSuites, bool enableServerCertAuth);
+				const string& enabledCipherSuites, bool enableServerCertAuth,
+				int sslVersion);
 	/**
 	 * Copy constructor.
 	 * @param opt The other options to copy.
@@ -174,6 +183,13 @@ public:
 		return to_bool(opts_.enableServerCertAuth);
 	}
 	/**
+	 * Returns the SSL/TLS version in use.
+	 * @return int
+	 */
+	int get_ssl_version() const {
+		return sslVersion_;
+	}
+	/**
 	 * Sets the file containing the public digital certificates trusted by
 	 * the client.
 	 * @param trustStore The file in PEM format containing the public
@@ -224,6 +240,11 @@ public:
 	 *  						  certificate
 	 */
 	void set_enable_server_cert_auth(bool enablServerCertAuth);
+	/**
+	 * Set the SSL/TLS version to use.
+	 * @param sslVersion The ssl version to use.
+	 */
+	void set_ssl_version(int sslVersion);
 };
 
 /**

--- a/src/mqtt/ssl_options.h
+++ b/src/mqtt/ssl_options.h
@@ -67,14 +67,6 @@ class ssl_options
 	 */
 	string enabledCipherSuites_;
 
-	/** 
-	 * The SSL/TLS version to use. Specify one of MQTT_SSL_VERSION_DEFAULT (0),
-	 * MQTT_SSL_VERSION_TLS_1_0 (1), MQTT_SSL_VERSION_TLS_1_1 (2) or 
-	 * MQTT_SSL_VERSION_TLS_1_2 (3).
-	 * Only used if struct_version is >= 1.
-	 */
-	int sslVersion_;
-
 	/** The connect options has special access */
 	friend class connect_options;
 	friend class connect_options_test;
@@ -121,11 +113,12 @@ public:
 	 * will present to the server during the SSL handshake.
 	 * @param enableServerCertAuth True/False option to enable verification of
 	 * the server certificate
+	 * @param sslVersion option to force the TLS version to use. @see set_ssl_version
 	 */
 	ssl_options(const string& trustStore, const string& keyStore,
 				const string& privateKey, const string& privateKeyPassword,
 				const string& enabledCipherSuites, bool enableServerCertAuth,
-				int sslVersion);
+				int sslVersion = 0);
 	/**
 	 * Copy constructor.
 	 * @param opt The other options to copy.
@@ -187,7 +180,7 @@ public:
 	 * @return int
 	 */
 	int get_ssl_version() const {
-		return sslVersion_;
+		return opts_.sslVersion;
 	}
 	/**
 	 * Sets the file containing the public digital certificates trusted by
@@ -242,7 +235,9 @@ public:
 	void set_enable_server_cert_auth(bool enablServerCertAuth);
 	/**
 	 * Set the SSL/TLS version to use.
-	 * @param sslVersion The ssl version to use.
+	 * @param sslVersion The ssl version to use. Specify one of 
+	 * MQTT_SSL_VERSION_DEFAULT (0), MQTT_SSL_VERSION_TLS_1_0 (1),
+	 * MQTT_SSL_VERSION_TLS_1_1 (2) or MQTT_SSL_VERSION_TLS_1_2 (3)
 	 */
 	void set_ssl_version(int sslVersion);
 };

--- a/src/ssl_options.cpp
+++ b/src/ssl_options.cpp
@@ -31,13 +31,15 @@ ssl_options::ssl_options() : opts_(DFLT_C_STRUCT)
 
 ssl_options::ssl_options(const string& trustStore, const string& keyStore,
 						 const string& privateKey, const string& privateKeyPassword,
-						 const string& enabledCipherSuites, bool enableServerCertAuth)
+						 const string& enabledCipherSuites, bool enableServerCertAuth,
+						 int sslVersion)
 			: opts_(DFLT_C_STRUCT), trustStore_(trustStore), keyStore_(keyStore),
 				privateKey_(privateKey), privateKeyPassword_(privateKeyPassword),
 				enabledCipherSuites_(enabledCipherSuites)
 {
 	update_c_struct();
 	opts_.enableServerCertAuth = enableServerCertAuth;
+	opts_.sslVersion = sslVersion;
 }
 
 ssl_options::ssl_options(const ssl_options& opt)
@@ -133,6 +135,11 @@ void ssl_options::set_enabled_cipher_suites(const string& enabledCipherSuites)
 void ssl_options::set_enable_server_cert_auth(bool enableServerCertAuth)
 {
 	opts_.enableServerCertAuth = to_int(enableServerCertAuth);
+}
+
+void ssl_options::set_ssl_version(int sslVersion)
+{
+	opts_.sslVersion = sslVersion;
 }
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Upgrade the Paho MQTT C++ SSL version option in order to be capable to set it and read the SSLversion option from Paho MQTT C.