### PR TITLE
FindPahoMqttC unable to find library if Paho MQTT C is compiled as a static library

### DIFF
--- a/cmake/FindPahoMqttC.cmake
+++ b/cmake/FindPahoMqttC.cmake
@@ -5,6 +5,10 @@ if(PAHO_WITH_SSL)
 else()
     set(_PAHO_MQTT_C_LIB_NAME paho-mqtt3a)
 endif()
+# add suffix when using static Paho MQTT C library variant
+if(PAHO_MQTT_C_STATIC)
+    set(_PAHO_MQTT_C_LIB_NAME ${_PAHO_MQTT_C_LIB_NAME}-static)
+endif()
 
 find_library(PAHO_MQTT_C_LIBRARIES NAMES ${_PAHO_MQTT_C_LIB_NAME})
 unset(_PAHO_MQTT_C_LIB_NAME)


### PR DESCRIPTION
I have included `paho.mqtt.cpp` to a CMake project as a Conan dependency:
```
[requires]
paho-c/1.3.0@conan/stable
paho-cpp/1.0.1@conan/stable
```
By default Conan provides statically compiled libraries. When `paho.mqtt.c` is compiled that way, the labrary file has a `-static` suffix - according to [conanfile.py](https://github.com/eclipse/paho.mqtt.c/blob/master/conanfile.py). Because of that, when i use `find_package(PahoMqttCpp)`, the following error occurs:
```
  Could NOT find PahoMqttC (missing: PAHO_MQTT_C_LIBRARIES)
```
I have introduces a new variable `PAHO_MQTT_C_STATIC` to conditionally append the suffix. This way, a static dependency can be added using the following:
```
SET(PAHO_MQTT_C_STATIC ON)
find_package(PahoMqttCpp)
```


P.S.: for the time being, it is possible to build against static libraries by adding the following in your project's `CMakeLists.txt`:
```
find_library(PAHO_MQTT_C_LIBRARIES NAMES paho-mqtt3as-static)
find_package(PahoMqttCpp)
```