### PR TITLE
CMAKE_MODULE_PATH is incorrectly set if paho.mqtt.cpp is compiled as a part of a bigger CMake project.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ endif()
 ## --- Build directories ---
 
 # For the paho_mqtt_c module
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 add_subdirectory(src)
 
 # --- Documentation ---


### PR DESCRIPTION
If paho.mqtt.cpp is added to a bigger project (e.g. as a git submodule) and later included via `add_subdirectory`, the project fails to locate `FindPahoMqttC.cmake`.
This fix uses `CMAKE_CURRENT_SOURCE_DIR` instead of `CMAKE_SOURCE_DIR` to specify path to `FindPahoMqttC.cmake` relative to `paho.mqtt.cpp`'c root `CMakeLists.txt`.