### PR TITLE
Fixed issue when build-time options were not written into configuration

### DIFF
--- a/cmake/PahoMqttCppConfig.cmake.in
+++ b/cmake/PahoMqttCppConfig.cmake.in
@@ -1,3 +1,8 @@
+# save build-time options
+set(PAHO_BUILD_STATIC @PAHO_BUILD_STATIC@)
+set(PAHO_BUILD_SHARED @PAHO_BUILD_SHARED@)
+set(PAHO_WITH_SSL @PAHO_WITH_SSL@)
+
 include(CMakeFindDependencyMacro)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_dependency(PahoMqttC REQUIRED)


### PR DESCRIPTION
This could lead to CMake macros, find commands, etc. not working correctly, when package is included via find_package(PahoMqttCpp).
E.g. when `paho.mqtt.cpp` was built with `PAHO_WITH_SSL=True`, one should `set(PAHO_MQTT_SSL True)` before calling `find_package(PahoMqttCpp)`.