### PR TITLE
Fix minimum required version of the Paho C lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ First, build and install the Paho C library:
 ```
 $ git clone https://github.com/eclipse/paho.mqtt.c.git
 $ cd paho.mqtt.c
-$ git checkout v1.2.1
+$ git checkout v1.3.1
 $ cmake -Bbuild -H. -DPAHO_WITH_SSL=ON
 $ sudo cmake --build build/ --target install
 $ sudo ldconfig


### PR DESCRIPTION
Fix the minimum required version indicated on the install instructions
in the README.md file

Signed-off-by: Jose <joseespiriki@gmail.com>