### PR TITLE
Find required dependency Threads

### DIFF
--- a/cmake/PahoMqttCppConfig.cmake.in
+++ b/cmake/PahoMqttCppConfig.cmake.in
@@ -7,5 +7,6 @@ include(CMakeFindDependencyMacro)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
 find_dependency(PahoMqttC REQUIRED)
 list(REMOVE_AT CMAKE_MODULE_PATH -1)
+find_dependency(Threads REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@package_name@Targets.cmake")


### PR DESCRIPTION
The cmake configuration of a library should find all required dependencies, such that consumers can use the library without having to know about transient dependencies. This PR adds the required dependency `Threads` to the cmake config file.