### PR TITLE
cmake/FindMahoMqttC.cmake: fix static build

### DIFF
--- a/cmake/FindPahoMqttC.cmake
+++ b/cmake/FindPahoMqttC.cmake
@@ -5,10 +5,6 @@ if(PAHO_WITH_SSL)
 else()
     set(_PAHO_MQTT_C_LIB_NAME paho-mqtt3a)
 endif()
-# add suffix when using static Paho MQTT C library variant
-if(PAHO_BUILD_STATIC)
-    set(_PAHO_MQTT_C_LIB_NAME ${_PAHO_MQTT_C_LIB_NAME}-static)
-endif()
 
 find_library(PAHO_MQTT_C_LIBRARIES NAMES ${_PAHO_MQTT_C_LIB_NAME})
 unset(_PAHO_MQTT_C_LIB_NAME)


### PR DESCRIPTION
Static libraries of paho-mqtt-c are not suffixed with -static since version 1.3.2 and https://github.com/eclipse/paho.mqtt.c/commit/8cc51c78b76a1eabd1df3124b0887ce8b01070ff

See: https://github.com/eclipse/paho.mqtt.c/pull/704

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>