### PR TITLE
Update build doc to use paho C v1.3.6 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Before building the C++ library, first, build and install the Paho C library:
 ```
 $ git clone https://github.com/eclipse/paho.mqtt.c.git
 $ cd paho.mqtt.c
-$ git checkout v1.3.1
+$ git checkout v1.3.6
 
 $ cmake -Bbuild -H. -DPAHO_WITH_SSL=ON -DPAHO_ENABLE_TESTING=OFF
 $ sudo cmake --build build/ --target install


### PR DESCRIPTION
Update build documentation to use paho.c v1.3.6 instead of v1.3.1.
Build with v1.3.1 was failing due to missing struct members of MQTTAsync_createOptions.
Commit 0893505 on this repo updated the Paho C build script to v1.3.6 but the documentation was not updated