### PR TITLE
added /build/ folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ Makefile.in
 *.lo
 *.o
 *.stamp
+/build/
+

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ Makefile.in
 *.o
 *.stamp
 /build/
-


### PR DESCRIPTION
This PR is concepted to include a new entry on .gitignore to exclude `/build/` folder created during building process out of the version control.