### PR TITLE
avoid adding Paho MQTT C library twice

### DIFF
--- a/cmake/FindPahoMqttC.cmake
+++ b/cmake/FindPahoMqttC.cmake
@@ -17,7 +17,9 @@ find_library(PAHO_MQTT_C_LIBRARIES NAMES ${_PAHO_MQTT_C_LIB_NAME})
 unset(_PAHO_MQTT_C_LIB_NAME)
 find_path(PAHO_MQTT_C_INCLUDE_DIRS NAMES MQTTAsync.h)
 
-add_library(PahoMqttC::PahoMqttC UNKNOWN IMPORTED)
+if (NOT TARGET PahoMqttC::PahoMqttC)
+    add_library(PahoMqttC::PahoMqttC UNKNOWN IMPORTED)
+endif ()
 
 set_target_properties(PahoMqttC::PahoMqttC PROPERTIES
     IMPORTED_LOCATION "${PAHO_MQTT_C_LIBRARIES}"


### PR DESCRIPTION
If a library is included that itself uses the Paho MQTT C++ it is not possible to add Paho MQTT C++ a second time. This results in the following message

`|   add_library cannot create imported target "PahoMqttC::PahoMqttC" because`
`|   another target with the same name already exists.`

It is not always possible to avoid such scenario (e.g. if third party software is used), so it is better to prevent this error.