### PR TITLE
Add paho.mqtt.c as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/externals/paho-mqtt-c"]
+	path = src/externals/paho-mqtt-c
+	url = https://github.com/eclipse/paho.mqtt.c.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ endif()
 option(PAHO_BUILD_SAMPLES "Build sample programs" FALSE)
 option(PAHO_BUILD_TESTS "Build tests" FALSE)
 option(PAHO_BUILD_DOCUMENTATION "Create and install the API documentation (requires Doxygen)" FALSE)
+option(PAHO_WITH_MQTT_C "Build paho.mqtt.c from the internal GIT submodule." FALSE)
 
 ## --- C++11 build flags ---
 

--- a/cmake/FindPahoMqttC.cmake
+++ b/cmake/FindPahoMqttC.cmake
@@ -6,11 +6,9 @@ else()
     set(_PAHO_MQTT_C_LIB_NAME paho-mqtt3a)
 endif()
 
-# add suffix when using static Paho MQTT C library variant on Windows
-if(WIN32)
-    if(PAHO_BUILD_STATIC)
-        set(_PAHO_MQTT_C_LIB_NAME ${_PAHO_MQTT_C_LIB_NAME}-static)
-    endif()
+# add suffix when using static Paho MQTT C library variant 
+if(PAHO_BUILD_STATIC)
+    set(_PAHO_MQTT_C_LIB_NAME ${_PAHO_MQTT_C_LIB_NAME}-static)
 endif()
 
 if(PAHO_WITH_MQTT_C)

--- a/cmake/FindPahoMqttC.cmake
+++ b/cmake/FindPahoMqttC.cmake
@@ -13,22 +13,36 @@ if(WIN32)
     endif()
 endif()
 
-find_library(PAHO_MQTT_C_LIBRARIES NAMES ${_PAHO_MQTT_C_LIB_NAME})
-unset(_PAHO_MQTT_C_LIB_NAME)
-find_path(PAHO_MQTT_C_INCLUDE_DIRS NAMES MQTTAsync.h)
+if(PAHO_WITH_MQTT_C)
+    # Build the paho.mqtt.c library from the submodule
+    add_subdirectory(externals/paho-mqtt-c)
+    add_library(PahoMqttC::PahoMqttC ALIAS ${_PAHO_MQTT_C_LIB_NAME})
 
-add_library(PahoMqttC::PahoMqttC UNKNOWN IMPORTED)
+    ## install paho.mqtt.c library (appending to PahoMqttCpp export)
+    install(TARGETS ${_PAHO_MQTT_C_LIB_NAME} EXPORT PahoMqttCpp
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-set_target_properties(PahoMqttC::PahoMqttC PROPERTIES
-    IMPORTED_LOCATION "${PAHO_MQTT_C_LIBRARIES}"
-    INTERFACE_INCLUDE_DIRECTORIES "${PAHO_MQTT_C_INCLUDE_DIRS}"
-    IMPORTED_LINK_INTERFACE_LANGUAGES "C")
-if(PAHO_WITH_SSL)
+    find_path(PAHO_MQTT_C_INCLUDE_DIRS NAMES MQTTAsync.h 
+        HINTS ${CMAKE_CURRENT_SOURCE_DIR}/externals/paho-mqtt-c/src)
+else()
+    find_library(PAHO_MQTT_C_LIBRARIES NAMES ${_PAHO_MQTT_C_LIB_NAME})
+    unset(_PAHO_MQTT_C_LIB_NAME)
+    find_path(PAHO_MQTT_C_INCLUDE_DIRS NAMES MQTTAsync.h)
+
+    add_library(PahoMqttC::PahoMqttC UNKNOWN IMPORTED)
+
     set_target_properties(PahoMqttC::PahoMqttC PROPERTIES
-            INTERFACE_COMPILE_DEFINITIONS "OPENSSL=1"
-            INTERFACE_LINK_LIBRARIES "OpenSSL::SSL;OpenSSL::Crypto")
+        IMPORTED_LOCATION "${PAHO_MQTT_C_LIBRARIES}"
+        INTERFACE_INCLUDE_DIRECTORIES "${PAHO_MQTT_C_INCLUDE_DIRS}"
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C")
+endif()
+
+if(PAHO_WITH_SSL)
+set_target_properties(PahoMqttC::PahoMqttC PROPERTIES
+        INTERFACE_COMPILE_DEFINITIONS "OPENSSL=1"
+        INTERFACE_LINK_LIBRARIES "OpenSSL::SSL;OpenSSL::Crypto")
 endif()
 
 include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(PahoMqttC
-    REQUIRED_VARS PAHO_MQTT_C_LIBRARIES PAHO_MQTT_C_INCLUDE_DIRS)
+find_package_handle_standard_args(PahoMqttC REQUIRED_VARS PAHO_MQTT_C_INCLUDE_DIRS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,9 @@
 #     Frank Pagliughi - made the shared library optional
 #*******************************************************************************/
 
-find_package(PahoMqttC REQUIRED)
+if (NOT TARGET PahoMqttC::PahoMqttC)
+    find_package(PahoMqttC REQUIRED)
+endif()
 
 # --- The headers ---
 


### PR DESCRIPTION
Adding `paho.mqtt.c` as a submodule allows to use CMake `FetchContent` for dependency management. Furthermore, users can add `paho.mqtt.cpp` as a GIT submodule by calling CMake `add_subdirectory`. A CMake example for `FetchContent`:

```cmake
set(PAHO_BUILD_SHARED OFF)
set(PAHO_BUILD_STATIC ON)
set(PAHO_ENABLE_TESTING OFF)
set(PAHO_BUILD_TESTS OFF)

# Instruct paho.mqtt.cpp to build paho.mqtt.c from internal submodule
set(PAHO_WITH_MQTT_C ON)

# Fetch from fork until PR request is accepted
FetchContent_Declare(
    paho-mqttpp3-static
    GIT_REPOSITORY https://github.com/HpLightcorner/paho.mqtt.cpp.git
    GIT_TAG mqtt-c-submodule
)

FetchContent_MakeAvailable(paho-mqttpp3-static)
target_include_directories(${PROJECT_NAME} PRIVATE
     ${paho-mqttpp3-static_SOURCE_DIR}/src
)

target_link_libraries(${PROJECT_NAME} PRIVATE
    paho-mqttpp3-static
)
```

The PR also includes changes proposed by #350 
Tested on Windows for static and dynamic builds.
