### PR TITLE
Update documentation on get_mqtt_version()

### DIFF
--- a/src/mqtt/connect_options.h
+++ b/src/mqtt/connect_options.h
@@ -253,6 +253,7 @@ public:
 	  *     fails, fall back to 3.1
 	  * @li MQTTVERSION_3_1 (3) = only try version 3.1
 	  * @li MQTTVERSION_3_1_1 (4) = only try version 3.1.1
+	  * @li MQTTVERSION_5 (5) = only try version 5
 	  */
 	int get_mqtt_version() const { return opts_.MQTTVersion; }
 	/**


### PR DESCRIPTION
 MQTT version 5 was missing from the documentation of get_mqtt_version(), which was a bit confusing for a newbie.