### PR TITLE
Fix set_mqtt_version typo in create_options class

### DIFF
--- a/src/mqtt/create_options.h
+++ b/src/mqtt/create_options.h
@@ -112,7 +112,7 @@ public:
 	 * Sets the MQTT version used to create the client.
 	 * @param ver The MQTT version used to create the client.
 	 */
-	void set_mqtt_verison(int ver) { opts_.MQTTVersion = ver; }
+	void set_mqtt_version(int ver) { opts_.MQTTVersion = ver; }
 	/**
 	 * Whether the oldest messages are deleted when the output buffer is
 	 * full.


### PR DESCRIPTION
fixing typo from `set_mqtt_verison` to `set_mqtt_version`