### PR TITLE
Fix nodiscard warnings in sync client

### DIFF
--- a/src/mqtt/client.h
+++ b/src/mqtt/client.h
@@ -68,17 +68,17 @@ class client : private callback
 	// Most are launched in a separate thread, for convenience, except
 	// message_arrived, for performance.
 	void connected(const string& cause) override {
-		std::async(std::launch::async, &callback::connected, userCallback_, cause);
+		std::async(std::launch::async, &callback::connected, userCallback_, cause).wait();
 	}
 	void connection_lost(const string& cause) override {
 		std::async(std::launch::async,
-				   &callback::connection_lost, userCallback_, cause);
+				   &callback::connection_lost, userCallback_, cause).wait();
 	}
 	void message_arrived(const_message_ptr msg) override {
 		userCallback_->message_arrived(msg);
 	}
 	void delivery_complete(delivery_token_ptr tok) override {
-		std::async(std::launch::async, &callback::delivery_complete, userCallback_, tok);
+		std::async(std::launch::async, &callback::delivery_complete, userCallback_, tok).wait();
 	}
 
 	/** Non-copyable */


### PR DESCRIPTION
In later C++ versions, std::async is marked nodiscard. See https://cplusplus.github.io/LWG/issue2856.
The code is correct in that it is properly blocking for the result, but it will now warn since this is considered "not the way".
Adding .wait() to the end of the calls, which explicitly waits on the future, should be the correct fix.

Fixes issue #340 