### PR TITLE
Silence warning for unused variable `rsp` in class unsubscribe_response

### DIFF
--- a/src/mqtt/server_response.h
+++ b/src/mqtt/server_response.h
@@ -190,7 +190,7 @@ class unsubscribe_response : public server_response
 		}
 	}
 
-	unsubscribe_response(MQTTAsync_successData* rsp) {}
+	unsubscribe_response(MQTTAsync_successData* rsp) { (void) rsp; }
 
 public:
 	/**


### PR DESCRIPTION
Trivial change to avoid the warning for unused variable `rsp`, problematic when using -Werror in a project including server_response.h as header.