### PR TITLE
Catch unhandled exception in mqtt::async_client

### DIFF
--- a/src/samples/async_consume.cpp
+++ b/src/samples/async_consume.cpp
@@ -49,14 +49,13 @@ const int  QOS = 1;
 
 int main(int argc, char* argv[])
 {
-	mqtt::async_client cli(SERVER_ADDRESS, CLIENT_ID);
-
 	auto connOpts = mqtt::connect_options_builder()
 		.clean_session(false)
 		.finalize();
 
 	try {
 		// Start consumer before connecting to make sure to not miss messages
+		mqtt::async_client cli(SERVER_ADDRESS, CLIENT_ID);
 
 		cli.start_consuming();
 

--- a/src/samples/async_publish.cpp
+++ b/src/samples/async_publish.cpp
@@ -125,27 +125,27 @@ public:
 
 int main(int argc, char* argv[])
 {
-	// A client that just publishes normally doesn't need a persistent
-	// session or Client ID unless it's using persistence, then the local
-	// library requires an ID to identify the persistence files.
+	try {		
+		// A client that just publishes normally doesn't need a persistent
+		// session or Client ID unless it's using persistence, then the local
+		// library requires an ID to identify the persistence files.
 
-	string	address  = (argc > 1) ? string(argv[1]) : DFLT_SERVER_ADDRESS,
-			clientID = (argc > 2) ? string(argv[2]) : CLIENT_ID;
+		string	address  = (argc > 1) ? string(argv[1]) : DFLT_SERVER_ADDRESS,
+				clientID = (argc > 2) ? string(argv[2]) : CLIENT_ID;
 
-	cout << "Initializing for server '" << address << "'..." << endl;
-	mqtt::async_client client(address, clientID, PERSIST_DIR);
+		cout << "Initializing for server '" << address << "'..." << endl;
+		mqtt::async_client client(address, clientID, PERSIST_DIR);
 
-	callback cb;
-	client.set_callback(cb);
+		callback cb;
+		client.set_callback(cb);
 
-	auto connOpts = mqtt::connect_options_builder()
-		.clean_session()
-		.will(mqtt::message(TOPIC, LWT_PAYLOAD, QOS))
-		.finalize();
+		auto connOpts = mqtt::connect_options_builder()
+			.clean_session()
+			.will(mqtt::message(TOPIC, LWT_PAYLOAD, QOS))
+			.finalize();
 
-	cout << "  ...OK" << endl;
+		cout << "  ...OK" << endl;
 
-	try {
 		cout << "\nConnecting..." << endl;
 		mqtt::token_ptr conntok = client.connect(connOpts);
 		cout << "Waiting for the connection..." << endl;

--- a/src/samples/async_publish_time.cpp
+++ b/src/samples/async_publish_time.cpp
@@ -84,44 +84,44 @@ uint64_t timestamp()
 
 int main(int argc, char* argv[])
 {
-	// The server URI (address)
-	string address = (argc > 1) ? string(argv[1]) : DFLT_SERVER_ADDRESS;
+	try {	
+		// The server URI (address)
+		string address = (argc > 1) ? string(argv[1]) : DFLT_SERVER_ADDRESS;
 
-	// The amount of time to run (in ms). Zero means "run forever".
-	uint64_t trun = (argc > 2) ? stoll(argv[2]) : 0LL;
+		// The amount of time to run (in ms). Zero means "run forever".
+		uint64_t trun = (argc > 2) ? stoll(argv[2]) : 0LL;
 
-	cout << "Initializing for server '" << address << "'..." << endl;
+		cout << "Initializing for server '" << address << "'..." << endl;
 
-	// We configure to allow publishing to the client while off-line,
-	// and that it's OK to do so before the 1st successful connection.
-	auto createOpts = mqtt::create_options_builder()
-						  .send_while_disconnected(true, true)
-					      .max_buffered_messages(MAX_BUFFERED_MESSAGES)
-						  .delete_oldest_messages()
-						  .finalize();
+		// We configure to allow publishing to the client while off-line,
+		// and that it's OK to do so before the 1st successful connection.
+		auto createOpts = mqtt::create_options_builder()
+							  .send_while_disconnected(true, true)
+							  .max_buffered_messages(MAX_BUFFERED_MESSAGES)
+							  .delete_oldest_messages()
+							  .finalize();
 
-	mqtt::async_client cli(address, "", createOpts);
+		mqtt::async_client cli(address, "", createOpts);
 
-	// Set callbacks for when connected and connection lost.
+		// Set callbacks for when connected and connection lost.
 
-	cli.set_connected_handler([&cli](const std::string&) {
-		std::cout << "*** Connected ("
-			<< timestamp() << ") ***" << std::endl;
-	});
+		cli.set_connected_handler([&cli](const std::string&) {
+			std::cout << "*** Connected ("
+				<< timestamp() << ") ***" << std::endl;
+		});
 
-	cli.set_connection_lost_handler([&cli](const std::string&) {
-		std::cout << "*** Connection Lost ("
-			<< timestamp() << ") ***" << std::endl;
-	});
+		cli.set_connection_lost_handler([&cli](const std::string&) {
+			std::cout << "*** Connection Lost ("
+				<< timestamp() << ") ***" << std::endl;
+		});
 
-	auto willMsg = mqtt::message("test/events", "Time publisher disconnected", 1, true);
-	auto connOpts = mqtt::connect_options_builder()
-		.clean_session()
-		.will(willMsg)
-		.automatic_reconnect(seconds(1), seconds(10))
-		.finalize();
+		auto willMsg = mqtt::message("test/events", "Time publisher disconnected", 1, true);
+		auto connOpts = mqtt::connect_options_builder()
+			.clean_session()
+			.will(willMsg)
+			.automatic_reconnect(seconds(1), seconds(10))
+			.finalize();
 
-	try {
 		// Note that we start the connection, but don't wait for completion.
 		// We configured to allow publishing before a successful connection.
 		cout << "Starting connection..." << endl;

--- a/src/samples/async_subscribe.cpp
+++ b/src/samples/async_subscribe.cpp
@@ -168,40 +168,33 @@ public:
 
 int main(int argc, char* argv[])
 {
-	// A subscriber often wants the server to remember its messages when its
-	// disconnected. In that case, it needs a unique ClientID and a
-	// non-clean session.
-
-	mqtt::async_client cli(SERVER_ADDRESS, CLIENT_ID);
-
-	mqtt::connect_options connOpts;
-	connOpts.set_clean_session(false);
-
-	// Install the callback(s) before connecting.
-	callback cb(cli, connOpts);
-	cli.set_callback(cb);
-
-	// Start the connection.
-	// When completed, the callback will subscribe to topic.
-
 	try {
+		// A subscriber often wants the server to remember its messages when its
+		// disconnected. In that case, it needs a unique ClientID and a
+		// non-clean session.
+
+		mqtt::async_client cli(SERVER_ADDRESS, CLIENT_ID);
+
+		mqtt::connect_options connOpts;
+		connOpts.set_clean_session(false);
+
+		// Install the callback(s) before connecting.
+		callback cb(cli, connOpts);
+		cli.set_callback(cb);
+
+		// Start the connection.
+		// When completed, the callback will subscribe to topic.
+
 		std::cout << "Connecting to the MQTT server..." << std::flush;
 		cli.connect(connOpts, nullptr, cb);
-	}
-	catch (const mqtt::exception& exc) {
-		std::cerr << "\nERROR: Unable to connect to MQTT server: '"
-			<< SERVER_ADDRESS << "'" << exc << std::endl;
-		return 1;
-	}
 
-	// Just block till user tells us to quit.
+        // Just block till user tells us to quit.
 
-	while (std::tolower(std::cin.get()) != 'q')
-		;
+        while (std::tolower(std::cin.get()) != 'q')
+            ;
 
-	// Disconnect
+        // Disconnect
 
-	try {
 		std::cout << "\nDisconnecting from the MQTT server..." << std::flush;
 		cli.disconnect()->wait();
 		std::cout << "OK" << std::endl;

--- a/src/samples/data_publish.cpp
+++ b/src/samples/data_publish.cpp
@@ -252,31 +252,31 @@ public:
 
 int main(int argc, char* argv[])
 {
-	string address = (argc > 1) ? string(argv[1]) : DFLT_ADDRESS;
+	try {	
+		string address = (argc > 1) ? string(argv[1]) : DFLT_ADDRESS;
 
-	#if defined(_WIN32)
-		mqtt::async_client cli(address, CLIENT_ID, MAX_BUFFERED_MSGS);
-	#else
-		encoded_file_persistence persist("elephant");
-		mqtt::async_client cli(address, CLIENT_ID, MAX_BUFFERED_MSGS, &persist);
-	#endif
+		#if defined(_WIN32)
+			mqtt::async_client cli(address, CLIENT_ID, MAX_BUFFERED_MSGS);
+		#else
+			encoded_file_persistence persist("elephant");
+			mqtt::async_client cli(address, CLIENT_ID, MAX_BUFFERED_MSGS, &persist);
+		#endif
 
-	auto connOpts = mqtt::connect_options_builder()
-		.keep_alive_interval(MAX_BUFFERED_MSGS * PERIOD)
-		.clean_session(true)
-		.automatic_reconnect(true)
-		.finalize();
+		auto connOpts = mqtt::connect_options_builder()
+			.keep_alive_interval(MAX_BUFFERED_MSGS * PERIOD)
+			.clean_session(true)
+			.automatic_reconnect(true)
+			.finalize();
 
-	// Create a topic object. This is a conventience since we will
-	// repeatedly publish messages with the same parameters.
-	mqtt::topic top(cli, TOPIC, QOS, true);
+		// Create a topic object. This is a conventience since we will
+		// repeatedly publish messages with the same parameters.
+		mqtt::topic top(cli, TOPIC, QOS, true);
 
-	// Random number generator [0 - 100]
-	random_device rnd;
-    mt19937 gen(rnd());
-    uniform_int_distribution<> dis(0, 100);
+		// Random number generator [0 - 100]
+		random_device rnd;
+		mt19937 gen(rnd());
+		uniform_int_distribution<> dis(0, 100);
 
-	try {
 		// Connect to the MQTT broker
 		cout << "Connecting to server '" << address << "'..." << flush;
 		cli.connect(connOpts)->wait();

--- a/src/samples/mqttpp_chat.cpp
+++ b/src/samples/mqttpp_chat.cpp
@@ -50,67 +50,67 @@
 
 int main(int argc, char* argv[])
 {
-	// The broker/server address
-	const std::string SERVER_ADDRESS("tcp://localhost:1883");
+    if (argc != 3) {
+        std::cout << "USAGE: mqttpp_chat <user> <group>" << std::endl;
+        return 1;
+    }
 
-	// The QoS to use for publishing and subscribing
-	const int QOS = 1;
-
-	// Tell the broker we don't want our own messages sent back to us.
-	const bool NO_LOCAL = true;
-
-	if (argc != 3) {
-		std::cout << "USAGE: mqttpp_chat <user> <group>" << std::endl;
-		return 1;
-	}
-
-	std::string chatUser  { argv[1] },
-				chatGroup { argv[2] },
-				chatTopic { "chat/"+chatGroup };
-
-	// LWT message is broadcast to other users if out connection is lost
-
-	auto lwt = mqtt::message(chatTopic, "<<<"+chatUser+" was disconnected>>>", QOS, false);
-
-	// Set up the connect options
-
-	mqtt::properties connectProperties{
-		{mqtt::property::SESSION_EXPIRY_INTERVAL, 604800}
-    };
-
-	auto connOpts = mqtt::connect_options_builder()
-		.mqtt_version(MQTTVERSION_5)
-		.properties(connectProperties)
-		.clean_start(true)
-		.will(std::move(lwt))
-		.keep_alive_interval(std::chrono::seconds(20))
-		.finalize();
-
-	mqtt::async_client cli(SERVER_ADDRESS, "",
-						   mqtt::create_options(MQTTVERSION_5));
-
-	// Set a callback for connection lost.
-	// This just exits the app.
-
-	cli.set_connection_lost_handler([](const std::string&) {
-		std::cout << "*** Connection Lost  ***" << std::endl;
-		exit(2);
-	});
-
-	// Set the callback for incoming messages
-
-	cli.set_message_callback([](mqtt::const_message_ptr msg) {
-		std::cout << msg->get_payload_str() << std::endl;
-	});
-
-	// We publish and subscribe to one topic,
-	// so a 'topic' object is helpful.
-
-	mqtt::topic topic { cli, "chat/"+chatGroup, QOS };
-
-	// Start the connection.
+    std::string chatUser  { argv[1] },
+                chatGroup { argv[2] },
+                chatTopic { "chat/"+chatGroup };
 
 	try {
+		// The broker/server address
+		const std::string SERVER_ADDRESS("tcp://localhost:1883");
+
+		// The QoS to use for publishing and subscribing
+		const int QOS = 1;
+
+		// Tell the broker we don't want our own messages sent back to us.
+		const bool NO_LOCAL = true;
+
+		// LWT message is broadcast to other users if out connection is lost
+
+		auto lwt = mqtt::message(chatTopic, "<<<"+chatUser+" was disconnected>>>", QOS, false);
+
+		// Set up the connect options
+
+		mqtt::properties connectProperties{
+			{mqtt::property::SESSION_EXPIRY_INTERVAL, 604800}
+		};
+
+		auto connOpts = mqtt::connect_options_builder()
+			.mqtt_version(MQTTVERSION_5)
+			.properties(connectProperties)
+			.clean_start(true)
+			.will(std::move(lwt))
+			.keep_alive_interval(std::chrono::seconds(20))
+			.finalize();
+
+		mqtt::async_client cli(SERVER_ADDRESS, "",
+							   mqtt::create_options(MQTTVERSION_5));
+
+		// Set a callback for connection lost.
+		// This just exits the app.
+
+		cli.set_connection_lost_handler([](const std::string&) {
+			std::cout << "*** Connection Lost  ***" << std::endl;
+			exit(2);
+		});
+
+		// Set the callback for incoming messages
+
+		cli.set_message_callback([](mqtt::const_message_ptr msg) {
+			std::cout << msg->get_payload_str() << std::endl;
+		});
+
+		// We publish and subscribe to one topic,
+		// so a 'topic' object is helpful.
+
+		mqtt::topic topic { cli, "chat/"+chatGroup, QOS };
+
+		// Start the connection.
+
 		std::cout << "Connecting to the chat server at '" << SERVER_ADDRESS
 			<< "'..." << std::flush;
 		auto tok = cli.connect(connOpts);
@@ -123,34 +123,25 @@ int main(int argc, char* argv[])
 		auto subOpts = mqtt::subscribe_options(NO_LOCAL);
 		topic.subscribe(subOpts)->wait();
 		std::cout << "Ok" << std::endl;
-	}
-	catch (const mqtt::exception& exc) {
-		std::cerr << "\nERROR: Unable to connect. "
-			<< exc.what() << std::endl;
-		return 1;
-	}
 
-	// Let eveyone know that a new user joined the conversation.
+        // Let everyone know that a new user joined the conversation.
 
-	topic.publish("<<" + chatUser + " joined the group>>");
+        topic.publish("<<" + chatUser + " joined the group>>");
 
-	// Read messages from the console and publish them.
-	// Quit when the use enters an empty line.
+        // Read messages from the console and publish them.
+        // Quit when the use enters an empty line.
 
-	std::string usrMsg;
+        std::string usrMsg;
 
-	while (std::getline(std::cin, usrMsg) && !usrMsg.empty()) {
-		usrMsg = chatUser + ": " + usrMsg;
-		topic.publish(usrMsg);
-	}
+        while (std::getline(std::cin, usrMsg) && !usrMsg.empty()) {
+            usrMsg = chatUser + ": " + usrMsg;
+            topic.publish(usrMsg);
+        }
 
-	// Let eveyone know that the user left the conversation.
+        // Let everyone know that the user left the conversation.
+        topic.publish("<<" + chatUser + " left the group>>")->wait();
 
-	topic.publish("<<" + chatUser + " left the group>>")->wait();
-
-	// Disconnect
-
-	try {
+        // Disconnect
 		std::cout << "Disconnecting from the chat server..." << std::flush;
 		cli.disconnect()->wait();
 		std::cout << "OK" << std::endl;

--- a/src/samples/multithr_pub_sub.cpp
+++ b/src/samples/multithr_pub_sub.cpp
@@ -139,24 +139,24 @@ void publisher_func(mqtt::async_client_ptr cli, multithr_counter::ptr_t counter)
 
 int main(int argc, char* argv[])
 {
-	 string address = (argc > 1) ? string(argv[1]) : DFLT_SERVER_ADDRESS;
+	try {	
+		string address = (argc > 1) ? string(argv[1]) : DFLT_SERVER_ADDRESS;
 
-	// Create an MQTT client using a smart pointer to be shared among threads.
-	auto cli = std::make_shared<mqtt::async_client>(address, CLIENT_ID);
+		// Create an MQTT client using a smart pointer to be shared among threads.
+		auto cli = std::make_shared<mqtt::async_client>(address, CLIENT_ID);
 
-	// Make a counter object also with a shared pointer.
-	auto counter = std::make_shared <multithr_counter>();
+		// Make a counter object also with a shared pointer.
+		auto counter = std::make_shared <multithr_counter>();
 
-	// Connect options for a persistent session and automatic reconnects.
-	auto connOpts = mqtt::connect_options_builder()
-		.clean_session(false)
-		.automatic_reconnect(seconds(2), seconds(30))
-		.finalize();
+		// Connect options for a persistent session and automatic reconnects.
+		auto connOpts = mqtt::connect_options_builder()
+			.clean_session(false)
+			.automatic_reconnect(seconds(2), seconds(30))
+			.finalize();
 
-	auto TOPICS = mqtt::string_collection::create({ "data/#", "command" });
-	const vector<int> QOS { 0, 1 };
+		auto TOPICS = mqtt::string_collection::create({ "data/#", "command" });
+		const vector<int> QOS { 0, 1 };
 
-	try {
 		// Start consuming _before_ connecting, because we could get a flood
 		// of stored messages as soon as the connection completes since
 		// we're using a persistent (non-clean) session with the broker.

--- a/src/samples/pub_speed_test.cpp
+++ b/src/samples/pub_speed_test.cpp
@@ -73,29 +73,29 @@ void token_wait_func()
 
 int main(int argc, char* argv[])
 {
-	string	address  = (argc > 1) ? string(argv[1]) : DFLT_SERVER_ADDRESS;
-	int		nMsg = (argc > 2) ? atoi(argv[2]) : DFLT_N_MSG;
-	size_t	msgSz = (size_t) ((argc > 3) ? atol(argv[3]) : DFLT_PAYLOAD_SIZE);
-	int		qos = (argc > 4) ? atoi(argv[4]) : DFLT_QOS;
+	try {	
+		string	address  = (argc > 1) ? string(argv[1]) : DFLT_SERVER_ADDRESS;
+		int		nMsg = (argc > 2) ? atoi(argv[2]) : DFLT_N_MSG;
+		size_t	msgSz = (size_t) ((argc > 3) ? atol(argv[3]) : DFLT_PAYLOAD_SIZE);
+		int		qos = (argc > 4) ? atoi(argv[4]) : DFLT_QOS;
 
-	cout << "Initializing for server '" << address << "'..." << flush;
-	mqtt::async_client cli(address, "");
+		cout << "Initializing for server '" << address << "'..." << flush;
+		mqtt::async_client cli(address, "");
 
-	mqtt::message willmsg(TOPIC, LWT_PAYLOAD, 1, true);
-	mqtt::will_options will(willmsg);
+		mqtt::message willmsg(TOPIC, LWT_PAYLOAD, 1, true);
+		mqtt::will_options will(willmsg);
 
-	mqtt::connect_options connOpts;
-	connOpts.set_clean_session(true);
-	connOpts.set_will(will);
+		mqtt::connect_options connOpts;
+		connOpts.set_clean_session(true);
+		connOpts.set_will(will);
 
-	// Create a payload
-	mqtt::binary payload;
-	for (size_t i=0; i<msgSz; ++i)
-		payload.push_back('a' + i%26);
+		// Create a payload
+		mqtt::binary payload;
+		for (size_t i=0; i<msgSz; ++i)
+			payload.push_back('a' + i%26);
 
-	cout << "OK" << endl;
+		cout << "OK" << endl;
 
-	try {
 		// Create the message (move payload into it)
 		auto msg = mqtt::make_message(TOPIC, std::move(payload), qos, false);
 

--- a/src/samples/rpc_math_cli.cpp
+++ b/src/samples/rpc_math_cli.cpp
@@ -51,25 +51,25 @@ const auto TIMEOUT = std::chrono::seconds(10);
 
 int main(int argc, char* argv[])
 {
-	if (argc < 4) {
-		cout << "USAGE: rpc_math_cli <add|mult> <num1> <num2> [... numN]" << endl;
-		return 1;
-	}
+	try {	
+		if (argc < 4) {
+			cout << "USAGE: rpc_math_cli <add|mult> <num1> <num2> [... numN]" << endl;
+			return 1;
+		}
 
-	constexpr int QOS = 1;
-	const string REQ_TOPIC_HDR { "requests/math/" };
+		constexpr int QOS = 1;
+		const string REQ_TOPIC_HDR { "requests/math/" };
 
-	mqtt::create_options createOpts(MQTTVERSION_5);
-	mqtt::async_client cli(SERVER_ADDRESS, "", createOpts);
+		mqtt::create_options createOpts(MQTTVERSION_5);
+		mqtt::async_client cli(SERVER_ADDRESS, "", createOpts);
 
-	auto connOpts = mqtt::connect_options_builder()
-					    .mqtt_version(MQTTVERSION_5)
-					    .clean_start()
-						.finalize();
+		auto connOpts = mqtt::connect_options_builder()
+							.mqtt_version(MQTTVERSION_5)
+							.clean_start()
+							.finalize();
 
-	cli.start_consuming();
+		cli.start_consuming();
 
-	try {
 		cout << "Connecting..." << flush;
 		mqtt::token_ptr tok = cli.connect(connOpts);
 		auto connRsp = tok->get_connect_response();

--- a/src/samples/rpc_math_srvr.cpp
+++ b/src/samples/rpc_math_srvr.cpp
@@ -91,19 +91,19 @@ double mult(const std::vector<double>& nums)
 
 int main(int argc, char* argv[])
 {
-	mqtt::create_options createOpts(MQTTVERSION_5);
-	mqtt::client cli(SERVER_ADDRESS, CLIENT_ID, createOpts);
-
-	auto connOpts = mqtt::connect_options_builder()
-					    .mqtt_version(MQTTVERSION_5)
-					    .keep_alive_interval(seconds(20))
-					    .clean_start(true)
-						.finalize();
-
-	const vector<string> TOPICS { "requests/math", "requests/math/#" };
-	const vector<int> QOS { 1, 1 };
-
 	try {
+		mqtt::create_options createOpts(MQTTVERSION_5);
+		mqtt::client cli(SERVER_ADDRESS, CLIENT_ID, createOpts);
+
+		auto connOpts = mqtt::connect_options_builder()
+							.mqtt_version(MQTTVERSION_5)
+							.keep_alive_interval(seconds(20))
+							.clean_start(true)
+							.finalize();
+
+		const vector<string> TOPICS { "requests/math", "requests/math/#" };
+		const vector<int> QOS { 1, 1 };
+
 		cout << "Connecting to the MQTT server..." << flush;
 		cli.connect(connOpts);
 		cli.subscribe(TOPICS, QOS);

--- a/src/samples/ssl_publish.cpp
+++ b/src/samples/ssl_publish.cpp
@@ -87,55 +87,55 @@ using namespace std;
 
 int main(int argc, char* argv[])
 {
-	string	address  = (argc > 1) ? string(argv[1]) : DFLT_SERVER_ADDRESS,
-			clientID = (argc > 2) ? string(argv[2]) : DFLT_CLIENT_ID;
-
-	// Note that we don't actually need to open the trust or key stores.
-	// We just need a quick, portable way to check that they exist.
-	{
-		ifstream tstore(TRUST_STORE);
-		if (!tstore) {
-			cerr << "The trust store file does not exist: " << TRUST_STORE << endl;
-			cerr << "  Get a copy from \"paho.mqtt.c/test/ssl/test-root-ca.crt\"" << endl;;
-			return 1;
-		}
-
-		ifstream kstore(KEY_STORE);
-		if (!kstore) {
-			cerr << "The key store file does not exist: " << KEY_STORE << endl;
-			cerr << "  Get a copy from \"paho.mqtt.c/test/ssl/client.pem\"" << endl;
-			return 1;
-		}
-    }
-
-	cout << "Initializing for server '" << address << "'..." << endl;
-	mqtt::async_client client(address, clientID);
-
-	callback cb;
-	client.set_callback(cb);
-
-	// Build the connect options, including SSL and a LWT message.
-
-	auto sslopts = mqtt::ssl_options_builder()
-					   .trust_store(TRUST_STORE)
-					   .key_store(KEY_STORE)
-					   .error_handler([](const std::string& msg) {
-						   std::cerr << "SSL Error: " << msg << std::endl;
-					   })
-					   .finalize();
-
-	auto willmsg = mqtt::message(LWT_TOPIC, LWT_PAYLOAD, QOS, true);
-
-	auto connopts = mqtt::connect_options_builder()
-					    .user_name("testuser")
-					    .password("testpassword")
-					    .will(std::move(willmsg))
-						.ssl(std::move(sslopts))
-						.finalize();
-
-	cout << "  ...OK" << endl;
-
 	try {
+		string	address  = (argc > 1) ? string(argv[1]) : DFLT_SERVER_ADDRESS,
+				clientID = (argc > 2) ? string(argv[2]) : DFLT_CLIENT_ID;
+
+		// Note that we don't actually need to open the trust or key stores.
+		// We just need a quick, portable way to check that they exist.
+		{
+			ifstream tstore(TRUST_STORE);
+			if (!tstore) {
+				cerr << "The trust store file does not exist: " << TRUST_STORE << endl;
+				cerr << "  Get a copy from \"paho.mqtt.c/test/ssl/test-root-ca.crt\"" << endl;;
+				return 1;
+			}
+
+			ifstream kstore(KEY_STORE);
+			if (!kstore) {
+				cerr << "The key store file does not exist: " << KEY_STORE << endl;
+				cerr << "  Get a copy from \"paho.mqtt.c/test/ssl/client.pem\"" << endl;
+				return 1;
+			}
+		}
+
+		cout << "Initializing for server '" << address << "'..." << endl;
+		mqtt::async_client client(address, clientID);
+
+		callback cb;
+		client.set_callback(cb);
+
+		// Build the connect options, including SSL and a LWT message.
+
+		auto sslopts = mqtt::ssl_options_builder()
+						   .trust_store(TRUST_STORE)
+						   .key_store(KEY_STORE)
+						   .error_handler([](const std::string& msg) {
+							   std::cerr << "SSL Error: " << msg << std::endl;
+						   })
+						   .finalize();
+
+		auto willmsg = mqtt::message(LWT_TOPIC, LWT_PAYLOAD, QOS, true);
+
+		auto connopts = mqtt::connect_options_builder()
+							.user_name("testuser")
+							.password("testpassword")
+							.will(std::move(willmsg))
+							.ssl(std::move(sslopts))
+							.finalize();
+
+		cout << "  ...OK" << endl;
+
 		// Connect using SSL/TLS
 
 		cout << "\nConnecting..." << endl;

--- a/src/samples/sync_consume.cpp
+++ b/src/samples/sync_consume.cpp
@@ -50,38 +50,38 @@ const string CLIENT_ID		{ "paho_cpp_sync_consume" };
 
 int main(int argc, char* argv[])
 {
-	mqtt::client cli(SERVER_ADDRESS, CLIENT_ID);
+	try {	
+		mqtt::client cli(SERVER_ADDRESS, CLIENT_ID);
 
-	auto connOpts = mqtt::connect_options_builder()
-		.user_name("user")
-		.password("passwd")
-		.keep_alive_interval(seconds(30))
-		.automatic_reconnect(seconds(2), seconds(30))
-		.clean_session(false)
-		.finalize();
+		auto connOpts = mqtt::connect_options_builder()
+			.user_name("user")
+			.password("passwd")
+			.keep_alive_interval(seconds(30))
+			.automatic_reconnect(seconds(2), seconds(30))
+			.clean_session(false)
+			.finalize();
 
-	// You can install a callback to change some connection data
-	// on auto reconnect attempts. To make a change, update the
-	// `connect_data` and return 'true'.
-	cli.set_update_connection_handler(
-		[](mqtt::connect_data& connData) {
-			string newUserName { "newuser" };
-			if (connData.get_user_name() == newUserName)
-				return false;
+		// You can install a callback to change some connection data
+		// on auto reconnect attempts. To make a change, update the
+		// `connect_data` and return 'true'.
+		cli.set_update_connection_handler(
+			[](mqtt::connect_data& connData) {
+				string newUserName { "newuser" };
+				if (connData.get_user_name() == newUserName)
+					return false;
 
-			cout << "Previous user: '" << connData.get_user_name()
-				<< "'" << endl;
-			connData.set_user_name(newUserName);
-			cout << "New user name: '" << connData.get_user_name()
-				<< "'" << endl;
-			return true;
-		}
-	);
+				cout << "Previous user: '" << connData.get_user_name()
+					<< "'" << endl;
+				connData.set_user_name(newUserName);
+				cout << "New user name: '" << connData.get_user_name()
+					<< "'" << endl;
+				return true;
+			}
+		);
 
-	const vector<string> TOPICS { "data/#", "command" };
-	const vector<int> QOS { 0, 1 };
+		const vector<string> TOPICS { "data/#", "command" };
+		const vector<int> QOS { 0, 1 };
 
-	try {
 		cout << "Connecting to the MQTT server..." << flush;
 		mqtt::connect_response rsp = cli.connect(connOpts);
 		cout << "OK\n" << endl;

--- a/src/samples/sync_consume_v5.cpp
+++ b/src/samples/sync_consume_v5.cpp
@@ -78,22 +78,22 @@ bool command_handler(const mqtt::message& msg)
 
 int main(int argc, char* argv[])
 {
-	mqtt::client cli(SERVER_ADDRESS, CLIENT_ID,
-					 mqtt::create_options(MQTTVERSION_5));
+	try {	
+		mqtt::client cli(SERVER_ADDRESS, CLIENT_ID,
+						 mqtt::create_options(MQTTVERSION_5));
 
-	auto connOpts = mqtt::connect_options_builder()
-		.mqtt_version(MQTTVERSION_5)
-		.automatic_reconnect(seconds(2), seconds(30))
-		.clean_session(false)
-		.finalize();
+		auto connOpts = mqtt::connect_options_builder()
+			.mqtt_version(MQTTVERSION_5)
+			.automatic_reconnect(seconds(2), seconds(30))
+			.clean_session(false)
+			.finalize();
 
-	// Dispatch table to handle incoming messages based on Subscription ID's.
-	std::vector<handler_t> handler {
-		data_handler,
-		command_handler
-	};
+		// Dispatch table to handle incoming messages based on Subscription ID's.
+		std::vector<handler_t> handler {
+			data_handler,
+			command_handler
+		};
 
-	try {
 		cout << "Connecting to the MQTT server..." << flush;
 		mqtt::connect_response rsp = cli.connect(connOpts);
 		cout << "OK\n" << endl;

--- a/src/samples/sync_publish.cpp
+++ b/src/samples/sync_publish.cpp
@@ -160,19 +160,19 @@ public:
 
 int main(int argc, char* argv[])
 {
-	std::cout << "Initialzing..." << std::endl;
-	sample_mem_persistence persist;
-	mqtt::client client(SERVER_ADDRESS, CLIENT_ID, &persist);
-
-	user_callback cb;
-	client.set_callback(cb);
-
-	mqtt::connect_options connOpts;
-	connOpts.set_keep_alive_interval(20);
-	connOpts.set_clean_session(true);
-	std::cout << "...OK" << std::endl;
-
 	try {
+		std::cout << "Initialzing..." << std::endl;
+		sample_mem_persistence persist;
+		mqtt::client client(SERVER_ADDRESS, CLIENT_ID, &persist);
+
+		user_callback cb;
+		client.set_callback(cb);
+
+		mqtt::connect_options connOpts;
+		connOpts.set_keep_alive_interval(20);
+		connOpts.set_clean_session(true);
+		std::cout << "...OK" << std::endl;
+
 		std::cout << "\nConnecting..." << std::endl;
 		client.connect(connOpts);
 		std::cout << "...OK" << std::endl;

--- a/src/samples/sync_reconnect.cpp
+++ b/src/samples/sync_reconnect.cpp
@@ -72,28 +72,28 @@ uint64_t timestamp()
 
 int main(int argc, char* argv[])
 {
+	try {	
 	// The server URI (address)
-	string address = (argc > 1) ? string(argv[1]) : DFLT_SERVER_ADDRESS;
+		string address = (argc > 1) ? string(argv[1]) : DFLT_SERVER_ADDRESS;
 
-	// The amount of time to run (in sec). Zero means "run forever".
-	uint64_t trun = (argc > 2) ? stoll(argv[2]) : 0LL;
+		// The amount of time to run (in sec). Zero means "run forever".
+		uint64_t trun = (argc > 2) ? stoll(argv[2]) : 0LL;
 
-	cout << "Initializing for server '" << address << "'..." << endl;
+		cout << "Initializing for server '" << address << "'..." << endl;
 
-	mqtt::client cli(address, "");
+		mqtt::client cli(address, "");
 
-	auto connOpts = mqtt::connect_options_builder()
-		.clean_session()
-		.finalize();
+		auto connOpts = mqtt::connect_options_builder()
+			.clean_session()
+			.finalize();
 
-	cli.set_timeout(seconds(3));
+		cli.set_timeout(seconds(3));
 
-	auto top = cli.get_topic("data/time", QOS);
+		auto top = cli.get_topic("data/time", QOS);
 
-	uint64_t	t = timestamp(),
-				tstart = t;
+		uint64_t	t = timestamp(),
+					tstart = t;
 
-	try {
 		// We need to connect once before we can use reconnect()
 		cli.connect(connOpts);
 

--- a/src/samples/topic_publish.cpp
+++ b/src/samples/topic_publish.cpp
@@ -58,14 +58,14 @@ const auto TIMEOUT = std::chrono::seconds(10);
 
 int main(int argc, char* argv[])
 {
-	string address = (argc > 1) ? string(argv[1]) : DFLT_SERVER_ADDRESS;
-
-	cout << "Initializing for server '" << address << "'..." << endl;
-	mqtt::async_client cli(address, "");
-
-	cout << "  ...OK" << endl;
-
 	try {
+		string address = (argc > 1) ? string(argv[1]) : DFLT_SERVER_ADDRESS;
+
+		cout << "Initializing for server '" << address << "'..." << endl;
+		mqtt::async_client cli(address, "");
+
+		cout << "  ...OK" << endl;
+
 		cout << "\nConnecting..." << endl;
 		cli.connect()->wait();
 		cout << "  ...OK" << endl;

--- a/src/samples/ws_publish.cpp
+++ b/src/samples/ws_publish.cpp
@@ -57,29 +57,29 @@ using namespace std;
 
 int main(int argc, char* argv[])
 {
-	string	address  = (argc > 1) ? string(argv[1]) : DFLT_SERVER_ADDRESS,
-			proxy = (argc > 2) ? string(argv[2]) : DFLT_PROXY_ADDRESS;
+	try {	
+		string	address  = (argc > 1) ? string(argv[1]) : DFLT_SERVER_ADDRESS,
+				proxy = (argc > 2) ? string(argv[2]) : DFLT_PROXY_ADDRESS;
 
-	cout << "Initializing for server '" << address << "'..." << endl;
-	if (!proxy.empty())
-		cout << "    with proxy '" << proxy << "'" << endl;
+		cout << "Initializing for server '" << address << "'..." << endl;
+		if (!proxy.empty())
+			cout << "    with proxy '" << proxy << "'" << endl;
 
-	mqtt::async_client client(address, "");
+		mqtt::async_client client(address, "");
 
-	// Build the connect options.
+		// Build the connect options.
 
-	auto connBuilder = mqtt::connect_options_builder();
+		auto connBuilder = mqtt::connect_options_builder();
 
-	if (!proxy.empty())
-		connBuilder.http_proxy(proxy);
+		if (!proxy.empty())
+			connBuilder.http_proxy(proxy);
 
-	auto connOpts = connBuilder
-		.keep_alive_interval(std::chrono::seconds(45))
-		.finalize();
+		auto connOpts = connBuilder
+			.keep_alive_interval(std::chrono::seconds(45))
+			.finalize();
 
-	cout << "  ...OK" << endl;
+		cout << "  ...OK" << endl;
 
-	try {
 		// Connect to the server
 
 		cout << "\nConnecting..." << endl;


### PR DESCRIPTION
- The constructor of the async_client relies on `MQTTAsync_createWithOptions` if it returns an error code it throws an exception. https://github.com/eclipse/paho.mqtt.cpp/blob/6bfe50769bda4b62b19da818d73a36eeb7059fc3/src/async_client.cpp#L117

  This happens for example if you link the wrong library (non ssl) and try to connect to an ssl host. Then the first experience with paho.mqtt.cpp is a segfault in your application because it is not yet known to the new user.

  ./test/unit/unit_tests =============================================================================== All tests passed (1337 assertions in 204 test cases)