### PR TITLE
Iterable string collection

### DIFF
--- a/src/mqtt/string_collection.h
+++ b/src/mqtt/string_collection.h
@@ -223,6 +223,12 @@ public:
 	 *
 	 */
 	char* const* c_arr() const { return (char* const *) cArr_.data(); }
+
+	using const_iterator = collection_type::const_iterator;
+
+	const_iterator begin() const { return coll_.begin(); }
+
+	const_iterator end() const { return coll_.end(); }
 };
 
 /////////////////////////////////////////////////////////////////////////////

--- a/test/unit/test_string_collection.cpp
+++ b/test/unit/test_string_collection.cpp
@@ -326,6 +326,85 @@ TEST_CASE("string_collection clear", "[collections]")
 	REQUIRE(size_t(0) == sc.size());
 }
 
+
+// ----------------------------------------------------------------------
+// Test the const_iterator class
+// ----------------------------------------------------------------------
+
+TEST_CASE("string_collection for each", "[collections]")
+{
+	string_collection sc(VEC);
+
+	size_t i = 0u;
+	for (const auto & string : sc) {
+		REQUIRE(sc[i] == sc[i]);
+		++i;
+	}
+	REQUIRE(i == sc.size());
+}
+
+TEST_CASE("string_collection iterator for with advance", "[collections]")
+{
+	string_collection sc(VEC);
+
+	size_t i = 0u;
+	for (auto it = sc.begin(); it != sc.end(); std::advance(it, 1)) {
+		REQUIRE(*it == sc[i]);
+		++i;
+	}
+	REQUIRE(i == sc.size());
+}
+
+TEST_CASE("string_collection iterator for with pre-increment", "[collections]")
+{
+	string_collection sc(VEC);
+
+	size_t i = 0u;
+	for (auto it = sc.begin(); it != sc.end(); ++it) {
+		REQUIRE(*it == sc[i]);
+		++i;
+	}
+	REQUIRE(i == sc.size());
+}
+
+TEST_CASE("string_collection iterator for with post increment", "[collections]")
+{
+	string_collection sc(VEC);
+
+	size_t i = 0u;
+	for (auto it = sc.begin(); it != sc.end(); it++) {
+		REQUIRE(*it == sc[i]);
+		++i;
+	}
+	REQUIRE(i == sc.size());
+}
+
+TEST_CASE("string_collection begin", "[collections]")
+{
+	string_collection sc(VEC);
+
+	REQUIRE(*(sc.begin()) == sc[0u]);
+}
+
+TEST_CASE("string_collection std copy", "[collections]")
+{
+	string_collection sc(VEC);
+
+	std::vector<std::string> output;
+	std::copy(
+		sc.begin(),
+		sc.end(),
+		std::back_inserter(output)
+	);
+
+	REQUIRE(sc.size() == output.size());
+
+	for (size_t i = 0u; i < sc.size(); ++i) {
+		REQUIRE(sc[i] == output[i]);
+	}
+}
+
+
 /////////////////////////////////////////////////////////////////////////////
 // 							name_value_collection
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This implements a simple iterator class on the `mqtt::string_collection` class. I wrote this for my own use as a convenience when working with string collections for logging from tokens, but thought it might be nice for other people too.

I only implemented a basic forward iterator, but there is nothing blocking making this a random access iterator: a forward iterator was all I needed.

This includes unit tests.