### PR TITLE
add token::get_message

### DIFF
--- a/src/mqtt/token.h
+++ b/src/mqtt/token.h
@@ -420,6 +420,13 @@ public:
 	 * @return The reason code for the operation.
 	 */
 	ReasonCode get_reason_code() const { return reasonCode_; }
+
+	/**
+	 * Get the error message from the C library
+	 * @return Error message for the operation
+	*/
+	string get_message() const { return errMsg_; }
+
 	/**
 	 * Blocks the current thread until the action this token is associated
 	 * with has completed.

--- a/src/mqtt/token.h
+++ b/src/mqtt/token.h
@@ -425,7 +425,7 @@ public:
 	 * Get the error message from the C library
 	 * @return Error message for the operation
 	*/
-	string get_message() const { return errMsg_; }
+	string get_error_message() const { return errMsg_; }
 
 	/**
 	 * Blocks the current thread until the action this token is associated


### PR DESCRIPTION
I ran into a situation where I wanted to get the error message from the underlying C library (this is when the failure callback is called for connect).

The workaround I made was doing a `const_cast` on the token reference passed to the callback, and then calling `try_wait`, in order to trigger `check_ret`, which includes the error message in the exception it throws.

It would be nicer if you could just access the message on the token like you can for the reason code and return code.