### PR TITLE
export dependencies

### DIFF
--- a/cmake/PahoMqttCppConfig.cmake.in
+++ b/cmake/PahoMqttCppConfig.cmake.in
@@ -2,11 +2,19 @@
 set(PAHO_BUILD_STATIC @PAHO_BUILD_STATIC@)
 set(PAHO_BUILD_SHARED @PAHO_BUILD_SHARED@)
 set(PAHO_WITH_SSL @PAHO_WITH_SSL@)
+set(PAHO_WITH_MQTT_C @PAHO_WITH_MQTT_C@)
 
 include(CMakeFindDependencyMacro)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
-#find_dependency(PahoMqttC REQUIRED)
 list(REMOVE_AT CMAKE_MODULE_PATH -1)
 find_dependency(Threads REQUIRED)
+
+if (NOT PAHO_WITH_MQTT_C)
+  find_dependency(eclipse-paho-mqtt-c REQUIRED)
+endif()
+
+if (PAHO_WITH_SSL)
+  find_dependency(OpenSSL REQUIRED)
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/@package_name@Targets.cmake")


### PR DESCRIPTION
When building with `PAHO_WITH_MQTT_C` and/or `PAHO_WITH_SSL`, the package config file doesn't correctly bring in these additional dependencies. This fixes that, so upstream projects pulling this in don't have to call `find_package` themselves on these dependencies.