### PR TITLE
fix: link in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ are made available under the terms of the Eclipse Public License v2.0
 and Eclipse Distribution License v1.0 which accompany this distribution.
 
 The Eclipse Public License is available at
-  https://www.eclipse.org/legal/epl-20/
+  https://www.eclipse.org/legal/epl-2.0/
 and the Eclipse Distribution License is available at
   http://www.eclipse.org/org/documents/edl-v10.php.
 


### PR DESCRIPTION
The link to the EPL is broken.  Fixed the link to make sure the license is valid