### PR TITLE
build(include): add topic_matcher.h

### DIFF
--- a/src/mqtt/CMakeLists.txt
+++ b/src/mqtt/CMakeLists.txt
@@ -41,6 +41,7 @@ install(
         subscribe_options.h
         thread_queue.h
         token.h
+        topic_matcher.h
         topic.h
         types.h
         will_options.h

--- a/src/mqtt/token.h
+++ b/src/mqtt/token.h
@@ -420,6 +420,13 @@ public:
 	 * @return The reason code for the operation.
 	 */
 	ReasonCode get_reason_code() const { return reasonCode_; }
+
+	/**
+	 * Get the error message from the C library
+	 * @return Error message for the operation
+	*/
+	string get_error_message() const { return errMsg_; }
+
 	/**
 	 * Blocks the current thread until the action this token is associated
 	 * with has completed.


### PR DESCRIPTION
This PR add the missing `topic_matcher.h` header to the install target of the includes.

Note: the develop branch was behind the master, so I took the liberty of fork and make the change from master and not develop