### PR TITLE
Implemented OpenSSL providers support

### DIFF
--- a/include/mqtt/ssl_options.h
+++ b/include/mqtt/ssl_options.h
@@ -105,6 +105,10 @@ private:
     /** ALPN protocol list, in wire format */
     std::basic_string<unsigned char> protos_;
 
+	/** OpenSSL provider name to be used if enabled. */
+	string providerName_;
+
+
     /** Callbacks from the C library */
     static int on_error(const char* str, size_t len, void* context);
     static unsigned on_psk(
@@ -150,12 +154,14 @@ public:
      * @param enableServerCertAuth True/False option to enable verification of
      * the server certificate
      * @param alpnProtos The ALPN protocols to try.
+     * @param providerName Name of the OpenSSL provider to use.
      */
     ssl_options(
         const string& trustStore, const string& keyStore, const string& privateKey,
         const string& privateKeyPassword, const string& enabledCipherSuites,
         bool enableServerCertAuth,
-        const std::vector<string> alpnProtos = std::vector<string>()
+        const std::vector<string> alpnProtos = std::vector<string>(),
+        const string& providerName = ""
     );
     /**
      * Argument constructor.
@@ -174,12 +180,14 @@ public:
      * @param enableServerCertAuth True/False option to enable verification
      *  						   of the server certificate
      * @param alpnProtos The ALPN protocols to try.
+     * @param providerName Name of the OpenSSL provider to use.
      */
     ssl_options(
         const string& trustStore, const string& keyStore, const string& privateKey,
         const string& privateKeyPassword, const string& caPath,
         const string& enabledCipherSuites, bool enableServerCertAuth,
-        const std::vector<string> alpnProtos = std::vector<string>()
+        const std::vector<string> alpnProtos = std::vector<string>(),
+        const string& providerName = ""
     );
     /**
      * Copy constructor.
@@ -360,6 +368,16 @@ public:
      * @param protos The list of ALPN protocols to be negotiated.
      */
     void set_alpn_protos(const std::vector<string>& protos);
+    /*
+	 * Returns current provider name which is in use.
+	 * @return string containing provider name.
+	 */
+	string get_provider_name() const { return providerName_; }
+ 	/**
+	 * Sets the provider name to be used.
+	 * @param name provider name to use
+	 */
+	void set_provider_name(const string& name);
 };
 
 /**
@@ -507,6 +525,14 @@ public:
         opts_.set_alpn_protos(protos);
         return *this;
     }
+	/**
+	 * Sets the provider name
+	 * @param name provider name
+	 */
+	auto provider_name(const string& name) -> self& {
+		opts_.set_provider_name(name);
+		return *this;
+	}
     /**
      * Finish building the options and return them.
      * @return The option struct as built.

--- a/src/ssl_options.cpp
+++ b/src/ssl_options.cpp
@@ -28,13 +28,15 @@ namespace mqtt {
 ssl_options::ssl_options(
     const string& trustStore, const string& keyStore, const string& privateKey,
     const string& privateKeyPassword, const string& enabledCipherSuites,
-    bool enableServerCertAuth, const std::vector<string> alpnProtos /*=std::vector<string>()*/
+    bool enableServerCertAuth, const std::vector<string> alpnProtos, /*=std::vector<string>()*/
+    const string& providerName
 )
     : trustStore_(trustStore),
       keyStore_(keyStore),
       privateKey_(privateKey),
       privateKeyPassword_(privateKeyPassword),
-      enabledCipherSuites_(enabledCipherSuites)
+      enabledCipherSuites_(enabledCipherSuites),
+      providerName_(providerName)
 {
     set_alpn_protos(alpnProtos);
     update_c_struct();
@@ -44,14 +46,16 @@ ssl_options::ssl_options(
 ssl_options::ssl_options(
     const string& trustStore, const string& keyStore, const string& privateKey,
     const string& privateKeyPassword, const string& caPath, const string& enabledCipherSuites,
-    bool enableServerCertAuth, const std::vector<string> alpnProtos /*=std::vector<string>()*/
+    bool enableServerCertAuth, const std::vector<string> alpnProtos, /*=std::vector<string>()*/
+    const string& providerName
 )
     : trustStore_(trustStore),
       keyStore_(keyStore),
       privateKey_(privateKey),
       privateKeyPassword_(privateKeyPassword),
       caPath_(caPath),
-      enabledCipherSuites_(enabledCipherSuites)
+      enabledCipherSuites_(enabledCipherSuites),
+      providerName_(providerName)
 {
     set_alpn_protos(alpnProtos);
     update_c_struct();
@@ -68,7 +72,8 @@ ssl_options::ssl_options(const ssl_options& other)
       enabledCipherSuites_(other.enabledCipherSuites_),
       errHandler_(other.errHandler_),
       pskHandler_(other.pskHandler_),
-      protos_(other.protos_)
+      protos_(other.protos_),
+      providerName_(other.providerName_)
 {
     update_c_struct();
 }
@@ -83,7 +88,8 @@ ssl_options::ssl_options(ssl_options&& other)
       enabledCipherSuites_(std::move(other.enabledCipherSuites_)),
       errHandler_(std::move(other.errHandler_)),
       pskHandler_(std::move(other.pskHandler_)),
-      protos_(std::move(other.protos_))
+      protos_(std::move(other.protos_)),
+      providerName_(std::move(other.providerName_))
 {
     update_c_struct();
 }
@@ -123,6 +129,11 @@ void ssl_options::update_c_struct()
         opts_.protos = nullptr;
         opts_.protos_len = 0;
     }
+	if (!providerName_.empty()) {
+		opts_.providerName = c_str(providerName_);
+	} else {
+		opts_.providerName = nullptr;
+	}
 }
 
 // --------------------------------------------------------------------------
@@ -195,6 +206,7 @@ ssl_options& ssl_options::operator=(const ssl_options& rhs)
     pskHandler_ = rhs.pskHandler_;
 
     protos_ = rhs.protos_;
+    providerName_ = rhs.providerName_;
 
     update_c_struct();
     return *this;
@@ -218,6 +230,7 @@ ssl_options& ssl_options::operator=(ssl_options&& rhs)
     pskHandler_ = std::move(rhs.pskHandler_);
 
     protos_ = std::move(rhs.protos_);
+    providerName_ = std::move(rhs.providerName_);
 
     update_c_struct();
     return *this;
@@ -339,6 +352,12 @@ void ssl_options::set_alpn_protos(const std::vector<string>& protos)
         opts_.protos = nullptr;
         opts_.protos_len = 0;
     }
+}
+
+void ssl_options::set_provider_name(const string& name)
+{
+	providerName_ = name;
+	opts_.providerName = c_str(providerName_);
 }
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Hi guys,

I have implemented support for OpenSSL providers. It's a new feature available from OpenSSL 3.x.x.

ssl_options class is extended by providerName_string containing OpenSSL provider name, which then this field is passed to Paho MQTT C library. Accessor and mutator functions are added to get and set provider name. 

Related Paho MQTT C PR: https://github.com/eclipse/paho.mqtt.c/pull/1528

Thank you,
Tomasz.