### PR TITLE
Update thread_queue.h to remove conflict with windows headers

### DIFF
--- a/include/mqtt/thread_queue.h
+++ b/include/mqtt/thread_queue.h
@@ -93,7 +93,7 @@ public:
     using size_type = typename Container::size_type;
 
     /** The maximum capacity of the queue. */
-    static constexpr size_type MAX_CAPACITY = std::numeric_limits<size_type>::max();
+    static constexpr size_type MAX_CAPACITY = (std::numeric_limits<size_type>::max)();
 
 private:
     /** Object lock */


### PR DESCRIPTION
Add parenthesis around MAX_CAPACITY evaluation to ensure it is not misinterpreted as a macro when using windows headers

First came across this when trying to compile with libcurl headers (curl/curl.h). 