### PR TITLE
remove const from connect_options_builder 'move' constructor

### DIFF
--- a/include/mqtt/connect_options.h
+++ b/include/mqtt/connect_options.h
@@ -672,7 +672,7 @@ public:
     /**
      * Move constructor from an existing set of options.
      */
-    explicit connect_options_builder(const connect_options&& opts) : opts_(std::move(opts)) {}
+    explicit connect_options_builder(connect_options&& opts) : opts_(std::move(opts)) {}
     /**
      * Creates the default options builder for an MQTT v3.x connection.
      * @return An options builder for an MQTT v3.x connection.


### PR DESCRIPTION
Hello,

The current constructor doesn't move `connect_options` because it's a const rvalue reference, which causes it to fall back to the copy constructor of `connect_options` even if `std::move` is used.