### PR TITLE
Initialize property storage in default constructor

### DIFF
--- a/include/mqtt/properties.h
+++ b/include/mqtt/properties.h
@@ -61,7 +61,7 @@ class property
     void copy(const MQTTProperty& other);
 
     friend class properties;
-    property() {}
+    property() : prop_{} {}
 
 public:
     /**


### PR DESCRIPTION
Fix uninitialized MQTTProperty in property default constructor.

The default constructor leaves MQTTProperty uninitialized:

    property() {}

This may result in undefined behavior when a default-constructed
property object is destroyed or reassigned.

Valgrind reports reads of uninitialized values:

    ==440992== Conditional jump or move depends on uninitialised value(s)
    ==440992==    at 0x5378F6D: MQTTProperty_getType (MQTTProperties.c:79)
    ==440992==    by 0x5352172: mqtt::property::~property() (properties.cpp:111)
    ==440992==    by 0x5287B7B: ~const_iterator (properties.h:308)

and on GCC 13 / glibc 2.42 this was observed to cause intermittent
crashes in the property destructor with:

    double free or corruption (out)

Initializing the storage:

    property() : prop_{} {}

ensures that MQTTProperty starts in a valid zero-initialized state.

After this change, the Valgrind warnings above are no longer reported,
and the observed crashes could no longer be reproduced.

