### PR TITLE
docs: fix EPL license link

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ are made available under the terms of the Eclipse Public License v2.0
 and Eclipse Distribution License v1.0 which accompany this distribution.
 
 The Eclipse Public License is available at
-  https://www.eclipse.org/legal/epl-20/
+  https://www.eclipse.org/legal/epl-2.0/
 and the Eclipse Distribution License is available at
   http://www.eclipse.org/org/documents/edl-v10.php.
 


### PR DESCRIPTION
## Summary
- replace the broken EPL link in `LICENSE` with the current Eclipse EPL 2.0 URL
- keep the rest of the license text unchanged

Fixes #574

## Verification
- `curl -I -L --max-time 20 https://www.eclipse.org/legal/epl-20/` returns HTTP 404
- `curl -I -L --max-time 20 https://www.eclipse.org/legal/epl-2.0/` returns HTTP 200
- `rg -n "epl-20|epl-2\.0" LICENSE NOTICE notice.html` confirms `LICENSE`, `NOTICE`, and `notice.html` now point at the same EPL 2.0 location
- `git diff --check`